### PR TITLE
@xtina-starr => Fix underline links in articles

### DIFF
--- a/components/article/stylesheets/sections.styl
+++ b/components/article/stylesheets/sections.styl
@@ -16,7 +16,7 @@ caption-styling()
   line-height 1.3
   p
     margin 40px 0
-    a:not(.is-jump-link,.artist-follow)
+    a:not(.is-jump-link):not(.artist-follow)
       fine-faux-underline()
     &:first-child
       margin-top 0


### PR DESCRIPTION
Closes #9 
https://github.com/artsy/microgravity/issues/9

Update to correct usage of pseudo-selector. 
