### PR TITLE
@xtina-starr - Refresh artwork images after the search page loads

### DIFF
--- a/apps/search/templates/image.jade
+++ b/apps/search/templates/image.jade
@@ -1,0 +1,7 @@
+img(
+  src= result.imageUrl()
+  width='50'
+  height='50'
+  alt= result.get('title')
+  onerror='this.style.display="none";'
+)

--- a/components/search_results/result.jade
+++ b/components/search_results/result.jade
@@ -1,6 +1,7 @@
 a.search-result(
   href= result.href()
   class= result.publishedClass && result.publishedClass()
+  data-id= result.get('id')
 )
   .search-result-thumbnail
     .search-result-thumbnail-fallback
@@ -8,7 +9,7 @@ a.search-result(
         src= result.imageUrl()
         width='50'
         height='50'
-        alt= result.get('display')
+        alt= result.get('title')
         onerror='this.style.display="none";'
       )
 

--- a/models/google_search_result.coffee
+++ b/models/google_search_result.coffee
@@ -3,6 +3,7 @@ _s = require 'underscore.string'
 sd = require('sharify').data
 Backbone = require 'backbone'
 moment = require 'moment'
+{ crop, fill } = require '../components/resizer/index.coffee'
 
 module.exports = class GooogleSearchResult extends Backbone.Model
 
@@ -10,6 +11,7 @@ module.exports = class GooogleSearchResult extends Backbone.Model
 
   initialize: (options) ->
     @set
+      id: @getId()
       display: @formatTitle(@get('title'))
       image_url: @imageUrl()
       display_model: @displayModel()
@@ -18,13 +20,22 @@ module.exports = class GooogleSearchResult extends Backbone.Model
     @set
       about: @about(@get('snippet'))
 
+  # Gets the id out of the url
+  getId: ->
+    id = @href().split('?')[0]
+    if id.split('/').length > 2
+      id = id.split('/')[2]
+    id
+
   href: ->
     @get('link')
       .replace(/http(s?):\/\/(w{3}\.)?artsy.net/, '')
       .replace('#!', '')
 
   imageUrl: ->
-    @get('pagemap')?.cse_thumbnail?[0].src or @get('pagemap')?.cse_image?[0].src
+    return "" if @get('display_model') is 'artwork'
+    src = @get('pagemap')?.cse_thumbnail?[0].src or @get('pagemap')?.cse_image?[0].src
+    crop src, width: 100, height: 100
 
   ogType: ->
     return @get('ogType') if @get('ogType')

--- a/test/models/google_search_result.coffee
+++ b/test/models/google_search_result.coffee
@@ -18,7 +18,7 @@ describe 'GoogleSearchResult', ->
       })
       result.get('about').should.equal 'cool post snippet'
       result.get('display').should.equal 'Post Title'
-      result.get('image_url').should.equal 'imgurl'
+      result.get('image_url').should.equal 'https://i.embed.ly/1/display/crop?url=imgurl&width=100&height=100&quality=95'
       result.get('location').should.equal '/post/cool-post'
       result.get('display_model').should.equal 'article'
 
@@ -32,7 +32,7 @@ describe 'GoogleSearchResult', ->
           cse_thumbnail: [{ src: 'imgurl' }]
       })
       result.get('display').should.equal 'Gene Title'
-      result.get('image_url').should.equal 'imgurl'
+      result.get('image_url').should.equal 'https://i.embed.ly/1/display/crop?url=imgurl&width=100&height=100&quality=95'
       result.get('location').should.equal '/gene/cool-gene'
       result.get('display_model').should.equal 'category'
 
@@ -47,7 +47,7 @@ describe 'GoogleSearchResult', ->
       })
       result.get('about').should.equal 'show description'
       result.get('display').should.equal 'Show Title'
-      result.get('image_url').should.equal 'imgurl'
+      result.get('image_url').should.equal 'https://i.embed.ly/1/display/crop?url=imgurl&width=100&height=100&quality=95'
       result.get('location').should.equal '/show/cool-show'
       result.get('display_model').should.equal 'show'
 
@@ -61,7 +61,7 @@ describe 'GoogleSearchResult', ->
           cse_thumbnail: [{ src: 'imgurl' }]
       })
       result.get('display').should.equal 'Artwork Title, Artist'
-      result.get('image_url').should.equal 'imgurl'
+      result.get('image_url').should.equal 'https://i.embed.ly/1/display/crop?url=imgurl&width=100&height=100&quality=95'
       result.get('location').should.equal '/artwork/cool-artwork'
       result.get('display_model').should.equal 'artwork'
 
@@ -75,7 +75,7 @@ describe 'GoogleSearchResult', ->
           cse_thumbnail: [{ src: 'imgurl' }]
       })
       result.get('display').should.equal 'Artist Name'
-      result.get('image_url').should.equal 'imgurl'
+      result.get('image_url').should.equal 'https://i.embed.ly/1/display/crop?url=imgurl&width=100&height=100&quality=95'
       result.get('location').should.equal '/artist/cool-artist'
       result.get('display_model').should.equal 'artist'
 


### PR DESCRIPTION
This addresses an issue that came up in slack ( https://artsy.slack.com/archives/collector-gmv/p1473334891000081 ) where the right image is not being assigned to an artwork in our google powered search results. This PR takes the same approach as Force, and just fetches the artwork directly and re-renders the image.

Also removed some outdated analytics code from this page. We will automatically be tracking links via segment now, so this should be fine.
