### PR TITLE
@broskoski => little cleanup and use lot standing instead of iterating through bidder positions

### DIFF
--- a/apps/artwork/components/bid/index.coffee
+++ b/apps/artwork/components/bid/index.coffee
@@ -7,11 +7,8 @@ template = -> require('./templates/bid.jade') arguments...
 query = """
   query artwork($id: String!, $sale_id: String!) {
     me {
-      bidder_status(artwork_id: $id, sale_id: $sale_id) {
+      lot_standing(artwork_id: $id, sale_id: $sale_id) {
         is_highest_bidder
-      }
-      bidder_positions(artwork_id: $id) {
-        is_winning
       }
     }
     artwork(id: $id) {

--- a/apps/artwork/components/bid/query/me.coffee
+++ b/apps/artwork/components/bid/query/me.coffee
@@ -1,8 +1,0 @@
-module.exports = """
-  me {
-    id
-    bidder_positions(artwork_id: $id) {
-      is_winning
-    }
-  }
-"""

--- a/apps/artwork/components/bid/templates/bid.jade
+++ b/apps/artwork/components/bid/templates/bid.jade
@@ -12,8 +12,8 @@
       span Reserve not met
     else
       span No reserve
-  if bidder && bidder.bidder_positions.length > 0 && typeof window !== 'undefined'
-    if _.find(bidder.bidder_positions, { is_winning: true })
+  if bidder && bidder.lot_standing && typeof window !== 'undefined'
+    if bidder.lot_standing.is_highest_bidder
       .artwork-auction-bid-module__bid-status__users-bid-status.highest-bid
         .user-bid-status-text Highest Bid
         .bidder-status-arrow

--- a/apps/artwork/components/bid/test/template.coffee
+++ b/apps/artwork/components/bid/test/template.coffee
@@ -61,7 +61,7 @@ describe 'Artwork bid templates', ->
 
     beforeEach ->
       @artwork.auction.is_open = true
-      @me =  { id: 'my unique id', bidder_positions: [{is_winning: true}] }
+      @me =  { id: 'my unique id', lot_standing: { is_highest_bidder: true } }
 
       @html = render('index')(
         artwork: @artwork
@@ -87,23 +87,8 @@ describe 'Artwork bid templates', ->
       @$('.artwork-auction-bid-module__bid-status__users-bid-status').hasClass('highest-bid').should.equal true
       @$('.artwork-auction-bid-module__bid-status__users-bid-status').hasClass('outbid').should.equal false
 
-    it 'displays user bidder status - highest bid if multiple bidder positions', ->
-      @me.bidder_positions = [{is_winning: false}, {is_winning: true}, {is_winning: false}]
-      @html = render('index')(
-        artwork: @artwork
-        me: @me
-        sd: {}
-        asset: (->)
-        _: _
-      )
-
-      @$ = cheerio.load(@html)
-
-      @$('.artwork-auction-bid-module__bid-status__users-bid-status').hasClass('highest-bid').should.equal true
-      @$('.artwork-auction-bid-module__bid-status__users-bid-status').hasClass('outbid').should.equal false
-
     it 'displays user bidder status - outbid', ->
-      me =  { id: 'my unique id', bidder_positions: [{is_winning: false}] }
+      me =  { id: 'my unique id', lot_standing: { is_highest_bidder: false } }
 
       @html = render('index')(
         artwork: @artwork
@@ -118,23 +103,8 @@ describe 'Artwork bid templates', ->
       @$('.artwork-auction-bid-module__bid-status__users-bid-status').hasClass('outbid').should.equal true
       @$('.artwork-auction-bid-module__bid-status__users-bid-status').hasClass('highest-bid').should.equal false
 
-    it 'displays user bidder status - outbid bid if multiple bidder positions', ->
-      @me.bidder_positions = [{is_winning: false}, {is_winning: false}, {is_winning: false}]
-      @html = render('index')(
-        artwork: @artwork
-        me: @me
-        sd: {}
-        asset: (->)
-        _: _
-      )
-
-      @$ = cheerio.load(@html)
-
-      @$('.artwork-auction-bid-module__bid-status__users-bid-status').hasClass('highest-bid').should.equal false
-      @$('.artwork-auction-bid-module__bid-status__users-bid-status').hasClass('outbid').should.equal true
-
     it 'displays correct bidding amount label with bids', ->
-      me =  { id: 'my unique id', bidder_positions: [{is_winning: false}] }
+      me =  { id: 'my unique id', lot_standing: { is_highest_bidder: false } }
 
       @html = render('index')(
         artwork: @artwork
@@ -152,7 +122,7 @@ describe 'Artwork bid templates', ->
 
     beforeEach ->
       @artwork.auction.is_open = true
-      @me =  { id: 'my unique id', bidder_positions: [] }
+      @me =  { id: 'my unique id',lot_standing: null }
 
       @html = render('index')(
         artwork: @artwork
@@ -189,7 +159,7 @@ describe 'Artwork bid templates', ->
     describe 'bidder with no bidder positions', ->
       beforeEach ->
         @artwork.auction.is_open = true
-        @me =  { id: 'my unique id', bidder_positions: [ {is_winning: true} ] }
+        @me =  { id: 'my unique id', lot_standing: { is_highest_bidder: true } }
 
         @html = render('index')(
           artwork: @artwork
@@ -209,7 +179,7 @@ describe 'Artwork bid templates', ->
   describe 'bidder with no bidder positions', ->
     beforeEach ->
       @artwork.auction.is_open = true
-      @me =  { id: 'my unique id', bidder_positions: [ {is_winning: false} ] }
+      @me =  { id: 'my unique id', lot_standing: { is_highest_bidder: false } }
 
       @html = render('index')(
         artwork: @artwork

--- a/apps/artwork/routes.coffee
+++ b/apps/artwork/routes.coffee
@@ -3,12 +3,6 @@ qs = require 'qs'
 metaphysics = require '../../lib/metaphysics'
 { METAPHYSICS_ENDPOINT, CURRENT_USER } = require('sharify').data
 
-userQuery = (user) ->
-  if user
-    require './components/bid/query/me.coffee'
-  else
-    ''
-
 query = (user) -> """
   query artwork($id: String!) {
     artwork(id: $id) {
@@ -89,7 +83,6 @@ query = (user) -> """
       #{require('./components/highlights/query.coffee')}
       #{require('./components/tabs/query.coffee')}
     }
-    #{userQuery(user)}
   }
 """
 
@@ -104,8 +97,6 @@ query = (user) -> """
     .then (data) ->
       res.locals.artwork = data.artwork
       res.locals.sd.ARTWORK = data.artwork
-      res.locals.me = data.me
-      res.locals.sd.ME = data.me
       res.locals.sd.SEADRAGON_URL = res.locals.asset('/assets/openseadragon.js')
       res.render 'index'
     .catch next

--- a/apps/feature/routes.coffee
+++ b/apps/feature/routes.coffee
@@ -92,7 +92,7 @@ metaphysics = require '../../lib/metaphysics'
         }
       }
       me {
-        bidder_status(
+        lot_standing(
           artwork_id: "#{req.params.artworkId}"
           sale_id: "#{req.params.id}"
         ) {
@@ -106,7 +106,7 @@ metaphysics = require '../../lib/metaphysics'
     } """
   .then ({ artwork, me }) ->
     res.locals.bidIncrements = artwork.sale_artwork.bid_increments
-    res.locals.myLastMaxBid = me?.bidder_status?.most_recent_bid.max_bid.cents
+    res.locals.myLastMaxBid = me?.lot_standing?.most_recent_bid.max_bid.cents
     render()
   .catch next
 

--- a/apps/feature/test/routes.coffee
+++ b/apps/feature/test/routes.coffee
@@ -41,7 +41,7 @@ describe '#bid', ->
   it 'handles empty bidder status from MP', (done) ->
     @metaphysics.returns Promise.resolve
       artwork: sale_artwork: bid_increments: [100, 200]
-      me: bidder_status: most_recent_bid: max_bid: cents: 100
+      me: lot_standing: most_recent_bid: max_bid: cents: 100
     routes.bid @req, @res, done
     Backbone.sync.args[0][2].success fabricate 'artwork'
     Backbone.sync.args[1][2].success [fabricate 'sale', is_auction: true]

--- a/models/current_user.coffee
+++ b/models/current_user.coffee
@@ -43,24 +43,6 @@ module.exports = class CurrentUser extends Backbone.Model
         options.success(false) if xhr.responseText?.match 'A user is required'
         options.error? arguments...
 
-  # Checks whether a user is the highest bidder for a given SaleArtwork.
-  #
-  # @param {String} saleArtwork
-  # @param {Object} options Provide `success` and `error` callbacks, successes with true or false
-
-  highestBidderFor: (saleArtwork, options = {}) ->
-    return options.success? false unless saleArtwork.get('highest_bid')
-    new Backbone.Collection().fetch
-      url: "#{API_URL}/api/v1/me/bidder_positions"
-      data:
-        sale_id: saleArtwork.get('sale').id
-        artwork_id: saleArtwork.get('artwork').id
-      success: (bidderPositions) ->
-        options.success? (bidderPositions.select((bp) ->
-          saleArtwork.get('highest_bid').id is bp.get('highest_bid')?.id
-        ).length > 0), bidderPositions.length > 0
-      error: options.error
-
   # Checks whether a user has favorited an artwork.
   #
   # @param {String} artworkId

--- a/test/models/current_user.coffee
+++ b/test/models/current_user.coffee
@@ -94,10 +94,6 @@ describe 'CurrentUser', ->
           done()
         Backbone.sync.args[0][2].success [bidder]
 
-  describe '#highestBidderFor', ->
-
-    it 'checks if the user is the highest bidder for an artwork in an auction'
-
   describe '#placeBid', ->
 
     it 'creates a new bid position given the right params'


### PR DESCRIPTION
This PR follows https://github.com/artsy/force/pull/128 :)

Since there's a gravity endpoint to return your bidding status based on a given lot, we no longer have to iterate through bidder positions to figure out whether or not you're the highest bidder.
