### PR TITLE
@xtina-starr => dont show 0 bids if there are none

### DIFF
--- a/components/auction_artwork_list/templates/artwork.jade
+++ b/components/auction_artwork_list/templates/artwork.jade
@@ -39,7 +39,7 @@ a.auction-artwork-list-item( href= auction.isAuctionPromo() ? ('/auction-artwork
                 = artwork.related().saleArtwork.currentBid()
           unless auction.isClosed()
             .aali-bid-count
-              | (#{artwork.related().saleArtwork.bidCount()})
+              | #{artwork.related().saleArtwork.formatBidCount()}
 
           if artwork.get('acquireable') && artwork.saleMessage()
             .aali-buy-now

--- a/models/sale_artwork.coffee
+++ b/models/sale_artwork.coffee
@@ -30,11 +30,15 @@ module.exports = class SaleArtwork extends Backbone.Model
   bidCount: ->
     count = @get('bidder_positions_count') or 0
     count = 0 unless @get('highest_bid_amount_cents')
+    count
+
+  bidCountLabel: ->
+    count = @bidCount()
     bids = "#{count} bid"
     bids += if count is 1 then '' else 's'
 
   formatBidCount: ->
-    if @bidCount() is '0 bids' then '' else "(#{@bidCount()})"
+    if @bidCount() is 0 then '' else "(#{@bidCountLabel()})"
 
   estimate: ->
     _.compact([@get('display_low_estimate_dollars'), @get('display_high_estimate_dollars')]).join('–') or
@@ -47,9 +51,9 @@ module.exports = class SaleArtwork extends Backbone.Model
       'Estimate'
 
   formatBidsAndReserve: ->
-    bid = @bidCount()
-    bid = '' if bid is '0 bids'
+    count = @bidCount()
+    label = if count is 0 then '' else @bidCountLabel()
     reserve = @reserveFormat[@get('reserve_status')]
-    reserve = "This work has a reserve" if reserve? and not bid
-    bidAndReserve = _.compact([bid, reserve]).join(', ')
+    reserve = "This work has a reserve" if reserve? and not label
+    bidAndReserve = _.compact([label, reserve]).join(', ')
     if bidAndReserve then "(#{bidAndReserve})" else ''

--- a/models/sale_artwork.coffee
+++ b/models/sale_artwork.coffee
@@ -33,6 +33,9 @@ module.exports = class SaleArtwork extends Backbone.Model
     bids = "#{count} bid"
     bids += if count is 1 then '' else 's'
 
+  formatBidCount: ->
+    if @bidCount() is '0 bids' then '' else "(#{@bidCount()})"
+
   estimate: ->
     _.compact([@get('display_low_estimate_dollars'), @get('display_high_estimate_dollars')]).join('–') or
     @get 'display_estimate_dollars'

--- a/test/models/sale_artwork.coffee
+++ b/test/models/sale_artwork.coffee
@@ -35,30 +35,30 @@ describe 'SaleArtwork', ->
       @saleArtwork.set display_minimum_next_bid_dollars: '$10'
       @saleArtwork.minBid().should.equal '$10'
 
-  describe '#bidCount', ->
+  describe '#bidCountLabel', ->
     it 'returns bid count in plural form if there are 0 bids', ->
       @saleArtwork.set bidder_positions_count: 0
       @saleArtwork.set highest_bid_amount_cents: 100
-      @saleArtwork.bidCount().should.equal '0 bids'
+      @saleArtwork.bidCountLabel().should.equal '0 bids'
 
     it 'returns bid count in singular form if 1', ->
       @saleArtwork.set bidder_positions_count: 1
       @saleArtwork.set highest_bid_amount_cents: 100
-      @saleArtwork.bidCount().should.equal '1 bid'
+      @saleArtwork.bidCountLabel().should.equal '1 bid'
 
     it 'returns bid count in plural form if greater than 1', ->
       @saleArtwork.set bidder_positions_count: 6
       @saleArtwork.set highest_bid_amount_cents: 100
-      @saleArtwork.bidCount().should.equal '6 bids'
+      @saleArtwork.bidCountLabel().should.equal '6 bids'
 
     it 'returns a blank string if attribute not present', ->
       @saleArtwork.unset 'bidder_positions_count'
-      @saleArtwork.bidCount().should.equal '0 bids'
+      @saleArtwork.bidCountLabel().should.equal '0 bids'
 
     it 'returns a blank string if highest_bid_amount_cents attribute not present', ->
       @saleArtwork.set bidder_positions_count: 6
       @saleArtwork.unset 'highest_bid_amount_cents'
-      @saleArtwork.bidCount().should.equal '0 bids'
+      @saleArtwork.bidCountLabel().should.equal '0 bids'
 
   describe '#formatBidCount', ->
 

--- a/test/models/sale_artwork.coffee
+++ b/test/models/sale_artwork.coffee
@@ -60,6 +60,22 @@ describe 'SaleArtwork', ->
       @saleArtwork.unset 'highest_bid_amount_cents'
       @saleArtwork.bidCount().should.equal '0 bids'
 
+  describe '#formatBidCount', ->
+
+    it 'returns an empty string if there are no bids because of no highest_bid_amount_cents', ->
+      @saleArtwork.set bidder_positions_count: 6
+      @saleArtwork.unset 'highest_bid_amount_cents'
+      @saleArtwork.formatBidCount().should.equal ''
+
+    it 'returns an empty string if there are no bids', ->
+      @saleArtwork.unset 'bidder_positions_count'
+      @saleArtwork.formatBidCount().should.equal ''
+
+    it 'returns the original count in parentheses if it exists', ->
+      @saleArtwork.set bidder_positions_count: 6
+      @saleArtwork.set highest_bid_amount_cents: 100
+      @saleArtwork.formatBidCount().should.equal '(6 bids)'
+
   describe '#formatBidsAndReserve', ->
     describe 'with no bids', ->
       it 'returns This work has a reserve if there is a reserve', ->


### PR DESCRIPTION
Same as https://github.com/artsy/force/pull/131 :)

We used to show "(0 bids)" if there were none yet on an artwork:
![image](https://cloud.githubusercontent.com/assets/2081340/18368295/4c3e98dc-75ed-11e6-865c-b1b0429b9ef6.png)

Instead, we now just remove the label:
![image](https://cloud.githubusercontent.com/assets/2081340/18368328/66d77fc4-75ed-11e6-89a2-d328260244e0.png)
