### PR TITLE
@mzikherman => sort auctions by live_start_at or end_at

### DIFF
--- a/apps/auctions/test/routes.coffee
+++ b/apps/auctions/test/routes.coffee
@@ -4,6 +4,7 @@ Backbone = require 'backbone'
 { fabricate } = require 'antigravity'
 Sale = require '../../../models/sale'
 routes = require '../routes'
+moment = require 'moment'
 
 describe 'Auctions routes', ->
   beforeEach ->
@@ -40,4 +41,35 @@ describe 'Auctions routes', ->
         @res.render.args[0][1].pastAuctions.should.eql [@closedSale]
         @res.render.args[0][1].currentAuctions.should.eql [@openSale]
         @res.render.args[0][1].upcomingAuctions.should.eql [@previewSale]
+        done()
+
+  describe '#index with sort', ->
+    beforeEach ->
+      @sales = [
+        @invalidSale = new Sale fabricate 'sale', eligible_sale_artworks_count: 0, auction_state: 'open', id: 'invalid-sale'
+        @openSale = new Sale fabricate 'sale', auction_state: 'open', id: 'open-sale', eligible_sale_artworks_count: 1, end_at: moment().add(5, 'days')
+        @openLiveSale = new Sale fabricate 'sale', auction_state: 'open', id: 'open-live-sale', eligible_sale_artworks_count: 1, end_at: moment().add(12, 'days'), live_start_at: moment().add(7, 'days')
+        @anotherOpenSale = new Sale fabricate 'sale', auction_state: 'open', id: 'another-open-sale', eligible_sale_artworks_count: 1, end_at: moment().add(10, 'days')
+      ]
+      @res = render: sinon.stub(), locals: sd: {}, asset: (->)
+
+    it 'sorts the open auctions by live_start_at or end_at', (done) ->
+      routes.index {}, @res
+      Backbone.sync.args[0][1].url.should.containEql '/api/v1/sales'
+      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 20, sort: '-created_at'
+      Backbone.sync.args[0][2].success(@sales)
+      Backbone.sync.callCount.should.equal 5
+      Backbone.sync.args[1][1].url().should.containEql '/api/v1/sale/invalid-sale/sale_artworks'
+      Backbone.sync.args[1][2].data.should.eql size: 5
+      _.defer => _.defer =>
+        @res.locals.sd.CURRENT_AUCTIONS.should.eql [@openSale, @openLiveSale, @anotherOpenSale]
+        @res.locals.sd.ARTWORK_DIMENSIONS.should.eql [
+          { id: 'open-sale', dimensions: [] }
+          { id: 'open-live-sale', dimensions: [] }
+          { id: 'another-open-sale', dimensions: [] }
+        ]
+        @res.render.args[0][0].should.equal 'index'
+        @res.render.args[0][1].pastAuctions.should.eql []
+        @res.render.args[0][1].currentAuctions.should.eql [@openSale, @openLiveSale, @anotherOpenSale]
+        @res.render.args[0][1].upcomingAuctions.should.eql []
         done()

--- a/models/sale.coffee
+++ b/models/sale.coffee
@@ -112,6 +112,9 @@ module.exports = class Sale extends Backbone.Model
   isAuctionPromoInquirable: ->
     @isAuctionPromo() and @isPreview()
 
+  sortableDate: ->
+    if @get('live_start_at')? then @get('live_start_at') else @get('end_at')
+
   # Feature support:
   fetchArtworks: ->
     @related().saleArtworks.fetchUntilEnd arguments...

--- a/test/models/sale.coffee
+++ b/test/models/sale.coffee
@@ -170,3 +170,15 @@ describe 'Sale', ->
 
     it 'corrects the state', ->
       @sale.get('auction_state').should.equal 'closed'
+
+  describe '#sortableDate', ->
+    it 'returns the live_start_at if it exists', ->
+      @sale.set
+        end_at: moment().add 2, 'days'
+        live_start_at: moment().add 1, 'days'
+      @sale.sortableDate().should.eql @sale.get('live_start_at')
+
+    it 'returns the end_at if no live_start_at exists', ->
+      @sale.set
+        end_at: moment().add 2, 'days'
+      @sale.sortableDate().should.eql @sale.get('end_at')


### PR DESCRIPTION
Same as: https://github.com/artsy/force/pull/137

We want to sort the `Current` auctions by either `live_start_at` or `end_at`
