### PR TITLE
Makes arrow cursor clickable in fair details

### DIFF
--- a/apps/art_fairs/index.styl
+++ b/apps/art_fairs/index.styl
@@ -52,7 +52,7 @@
     border-bottom 1px solid light-gray-border-color
 
   a.fairs-link
-    display table-row
+    display block
     vertical-align middle
     text-decoration none
 

--- a/apps/art_fairs/index.styl
+++ b/apps/art_fairs/index.styl
@@ -81,7 +81,7 @@
     overflow hidden
     text-overflow ellipsis
 
-  .art-fairs--fair-details::after
+  .fairs-link::after
     font-family 'artsy-icons'
     content "\e607"
     font-size 24px


### PR DESCRIPTION
Hi,

I was playing around with Eigen and noticed that the arrow cursor in fair details was not clickable, which was not consistent with the behaviour seen in [the actual fair page](https://m-staging.artsy.net/cosmoscow-2016). So I changed it to be 😉 

**Before**
<img src="https://cloud.githubusercontent.com/assets/1916041/18498083/1e9cfc86-7a0a-11e6-9a40-2bce196eed97.gif" width="200"> 

**After**
<img src="https://cloud.githubusercontent.com/assets/1916041/18498141/8e8153da-7a0a-11e6-91f9-633c15ee245e.gif" width="200">
