### PR TITLE
@craigspaeth: Add A/B routing code to MG

### DIFF
--- a/apps/gallery_partnerships/index.coffee
+++ b/apps/gallery_partnerships/index.coffee
@@ -11,3 +11,6 @@ app.set 'view engine', 'jade'
 
 app.get '/gallery-partnerships', routes.index
 app.get /^\/gallery-partnerships\/((?!edit$).)+$/, routes.index
+
+# Randomly redirect this link for a marketing A/B testing
+app.get '/partnership-opportunities', routes.mktoABTest

--- a/apps/gallery_partnerships/routes.coffee
+++ b/apps/gallery_partnerships/routes.coffee
@@ -18,3 +18,10 @@ getJSON = (callback) ->
   getJSON (err, data) ->
     return next err if err
     res.render 'index', data
+
+
+@mktoABTest = (req, res) ->
+  a = '/gallery-partnerships?utm_medium=email&utm_source=marketo&utm_campaign=seo-for-galleries&utm_content=partnerships-a'
+  b = 'http://pages.artsy.net/gallery-partnerships.html?utm_medium=email&utm_source=marketo&utm_campaign=seo-for-galleries&utm_content=partnerships-b'
+  res.redirect if Boolean(_.random 1) then a else b
+


### PR DESCRIPTION
We currently default to embedding Force views in Microgravity. That might be something to address on it's own b/c it's kinda a hacky thing to do and we should probably whitelist routes we want to do that for instead of by default. For now I'm just copypasting the code from Force b/c that's even more ideal than having MG redirect to Force, which then redirects to to A or B.
