### PR TITLE
@xtina-starr => Artwork page ref showz

### DIFF
--- a/apps/artwork/components/artist/index.styl
+++ b/apps/artwork/components/artist/index.styl
@@ -21,6 +21,14 @@
   &__images
     display flex
     margin-top 12px
+  &__content
+    &__exhibition-highlights
+      &__item
+        display flex
+        flex-direction row
+        margin 5px 0
+        &__text
+          margin-left 13px
   .artwork-artist-module__images-item img
     height auto
     max-width 100%

--- a/apps/artwork/components/artist/index.styl
+++ b/apps/artwork/components/artist/index.styl
@@ -23,6 +23,9 @@
     margin-top 12px
   &__content
     &__exhibition-highlights
+      &__title
+        avant-garde()
+        font-size avant-garde-font-size
       &__item
         display flex
         flex-direction row

--- a/apps/artwork/components/artist/query.coffee
+++ b/apps/artwork/components/artist/query.coffee
@@ -36,14 +36,11 @@ module.exports = """
         }
       }
     }
-    exhibition_history: shows {
+    exhibition_highlights(size: 16) {
       kind
-      year: start_at(format: "YYYY")
       name
+      start_at
       href
-      images {
-        url
-      }
       partner {
         ... on ExternalPartner {
           name
@@ -51,9 +48,6 @@ module.exports = """
         ... on Partner {
           name
         }
-      }
-      location {
-        city
       }
     }
   }

--- a/apps/artwork/components/artist/templates/exhibition.jade
+++ b/apps/artwork/components/artist/templates/exhibition.jade
@@ -4,19 +4,16 @@ a.aama-highlights-title.js-aama-accordion-link(data-id="shows-#{artist.id}") Exh
 
 .aama-tab-content.js-aama-content(data-id="shows-#{artist.id}")
   if shows.solo && shows.solo.length
-    .artwork-artist-header-cell-section
-      h2 Solo Shows on Artsy
-      for show in helpers.sortExhibitions(shows.solo)
-        +showItem(show, show.partner.name)
+    h2 Solo Shows on Artsy
+    for show in helpers.sortExhibitions(shows.solo)
+      +showItem(show, show.partner.name)
 
   if shows.group && shows.group.length
-    .artwork-artist-header-cell-section
-      h2 Group Shows on Artsy
-      for show in helpers.sortExhibitions(shows.group)
-        +showItem(show, show.partner.name)
+    h2 Group Shows on Artsy
+    for show in helpers.sortExhibitions(shows.group)
+      +showItem(show, show.partner.name)
 
   if shows.fair && shows.fair.length
-    .artwork-artist-header-cell-section
-      h2 Fair History on Artsy
-      for show in helpers.sortExhibitions(shows.fair)
-        +showItem(show, show.partner.name)
+    h2 Fair History on Artsy
+    for show in helpers.sortExhibitions(shows.fair)
+      +showItem(show, show.partner.name)

--- a/apps/artwork/components/artist/templates/exhibition.jade
+++ b/apps/artwork/components/artist/templates/exhibition.jade
@@ -1,0 +1,22 @@
+a.aama-highlights-title.js-aama-accordion-link(data-id="shows-#{artist.id}") Exhibition History On Artsy
+
+- var shows = helpers.groupBy(artist.exhibition_highlights.slice(0,15), 'kind')
+
+.aama-tab-content.js-aama-content(data-id="shows-#{artist.id}")
+  if shows.solo && shows.solo.length
+    .artwork-artist-header-cell-section
+      h2 Solo Shows on Artsy
+      for show in helpers.sortExhibitions(shows.solo)
+        +showItem(show, show.partner.name)
+
+  if shows.group && shows.group.length
+    .artwork-artist-header-cell-section
+      h2 Group Shows on Artsy
+      for show in helpers.sortExhibitions(shows.group)
+        +showItem(show, show.partner.name)
+
+  if shows.fair && shows.fair.length
+    .artwork-artist-header-cell-section
+      h2 Fair History on Artsy
+      for show in helpers.sortExhibitions(shows.fair)
+        +showItem(show, show.partner.name)

--- a/apps/artwork/components/artist/templates/exhibition.jade
+++ b/apps/artwork/components/artist/templates/exhibition.jade
@@ -1,19 +1,20 @@
-a.aama-highlights-title.js-aama-accordion-link(data-id="shows-#{artist.id}") Exhibition History On Artsy
+.aama-content.chevron-nav-list
+  a.aama-highlights-title.js-aama-accordion-link(data-id="shows-#{artist.id}") Exhibition History On Artsy
 
 - var shows = helpers.groupBy(artist.exhibition_highlights.slice(0,15), 'kind')
 
 .aama-tab-content.js-aama-content(data-id="shows-#{artist.id}")
   if shows.solo && shows.solo.length
-    h2 Solo Shows on Artsy
+    .artwork-artist-module__content__exhibition-highlights__title Solo Shows on Artsy
     for show in helpers.sortExhibitions(shows.solo)
       +showItem(show, show.partner.name)
 
   if shows.group && shows.group.length
-    h2 Group Shows on Artsy
+    .artwork-artist-module__content__exhibition-highlights__title Group Shows on Artsy
     for show in helpers.sortExhibitions(shows.group)
       +showItem(show, show.partner.name)
 
   if shows.fair && shows.fair.length
-    h2 Fair History on Artsy
+    .artwork-artist-module__content__exhibition-highlights__title Fair History on Artsy
     for show in helpers.sortExhibitions(shows.fair)
       +showItem(show, show.partner.name)

--- a/apps/artwork/components/artist/templates/highlights.jade
+++ b/apps/artwork/components/artist/templates/highlights.jade
@@ -1,4 +1,5 @@
-a.aama-highlights-title.js-aama-accordion-link(data-id="shows-#{artist.id}") Exhibition Highlights On Artsy
+.aama-content.chevron-nav-list
+  a.aama-highlights-title.js-aama-accordion-link(data-id="shows-#{artist.id}") Exhibition Highlights On Artsy
 
 .aama-tab-content.js-aama-content(data-id="shows-#{artist.id}")
   for show in helpers.sortExhibitions(artist.exhibition_highlights.slice(0,5))

--- a/apps/artwork/components/artist/templates/highlights.jade
+++ b/apps/artwork/components/artist/templates/highlights.jade
@@ -1,0 +1,5 @@
+a.aama-highlights-title.js-aama-accordion-link(data-id="shows-#{artist.id}") Exhibition Highlights On Artsy
+
+.aama-tab-content.js-aama-content(data-id="shows-#{artist.id}")
+  for show in helpers.sortExhibitions(artist.exhibition_highlights.slice(0,5))
+    +showItem(show, show.partner.name)

--- a/apps/artwork/components/artist/templates/index.jade
+++ b/apps/artwork/components/artist/templates/index.jade
@@ -1,3 +1,11 @@
+mixin showItem(show, trailingText)
+  .artwork-artist-module__content__exhibition-highlights__item
+    .artwork-artist-module__content__exhibition-highlights__item__date= helpers.date(show.start_at).year()
+    .artwork-artist-module__content__exhibition-highlights__item__text
+      = show.name
+      if trailingText
+        | #{!!show.name ? ', ' : ''}#{trailingText}
+
 - var artists = artwork.artists;
 
 if artists.length
@@ -42,3 +50,10 @@ if artists.length
             if artist.biography
               a.aama-biography-title.js-aama-accordion-link(data-id="biography-#{artist.id}") Biography
               .aama-tab-content.js-aama-content(data-id="biography-#{artist.id}")!= artist.biography
+
+        .artwork-artist-module__accordion
+          .aama-content.chevron-nav-list
+            if artist.exhibition_highlights && artist.exhibition_highlights.length <= 15
+              include exhibition
+            else if artist.exhibition_highlights && artist.exhibition_highlights.length > 15
+              include highlights

--- a/apps/artwork/components/artist/templates/index.jade
+++ b/apps/artwork/components/artist/templates/index.jade
@@ -2,7 +2,7 @@ mixin showItem(show, trailingText)
   .artwork-artist-module__content__exhibition-highlights__item
     .artwork-artist-module__content__exhibition-highlights__item__date= helpers.date(show.start_at).year()
     .artwork-artist-module__content__exhibition-highlights__item__text
-      = show.name
+      a(href=show.href)= show.name
       if trailingText
         | #{!!show.name ? ', ' : ''}#{trailingText}
 
@@ -52,8 +52,7 @@ if artists.length
               .aama-tab-content.js-aama-content(data-id="biography-#{artist.id}")!= artist.biography
 
         .artwork-artist-module__accordion
-          .aama-content.chevron-nav-list
-            if artist.exhibition_highlights && artist.exhibition_highlights.length <= 15
-              include exhibition
-            else if artist.exhibition_highlights && artist.exhibition_highlights.length > 15
-              include highlights
+          if artist.exhibition_highlights && artist.exhibition_highlights.length <= 15
+            include exhibition
+          else if artist.exhibition_highlights && artist.exhibition_highlights.length > 15
+            include highlights

--- a/apps/artwork/components/artist/test/fixture.coffee
+++ b/apps/artwork/components/artist/test/fixture.coffee
@@ -3,7 +3,7 @@
 module.exports =
   artist = [
     fabricate('artist',
-      counts: { artworks: 20, for_sale_artworks: 8 },
+      counts: { artworks: 20, for_sale_artworks: 8, partner_shows: 10 },
       carousel:
         images: [
           {
@@ -46,30 +46,14 @@ module.exports =
       ],
       bio: 'Born 1970, New York, New York, and based in Paris'
       biography: "This is Picasso's bio.",
-      exhibition_history: [
+      exhibition_highlights: [
         {
           href: "/show/retrospective"
-          images: [
-            {
-              thumb:
-                height: 58
-                url: "show_img.png"
-                width: 100
-            },
-            {
-              thumb:
-                height: 66
-                url: "show_img_2.png"
-                width: 100
-            }
-          ]
           kind: 'solo'
-          location: city: "New York"
           name: "Marcel Broodthaers: A Retrospective"
           partner:
-            href: "/museum-of-modern-art"
             name: "Museum of Modern Art"
-          year: "2016"
+          start_at: "1/1/2016"
         }
       ]
     ),
@@ -119,30 +103,14 @@ module.exports =
       ],
       bio: 'Born 1987, Cairo, Egypt, and lives and works in New York'
       biography: "Some cool bio.",
-      exhibition_history: [
+      exhibition_highlights: [
         {
-          href: "/show/reflective"
-          images: [
-            {
-              thumb:
-                height: 58
-                url: "img.png"
-                width: 100
-            },
-            {
-              thumb:
-                height: 66
-                url: "img_2.png"
-                width: 100
-            }
-          ]
-          kind: 'solo'
-          location: city: "New York"
-          name: "Reflective"
+          href: "/show/warhol"
+          kind: 'group'
+          name: "A Warhol Show"
           partner:
-            href: "/reflective"
-            name: "Artsy"
-          year: "2016"
+            name: "The Goog"
+          start_at: "1/1/2016"
         }
       ]
     )

--- a/apps/artwork/components/artist/test/template.coffee
+++ b/apps/artwork/components/artist/test/template.coffee
@@ -6,6 +6,7 @@ fs = require 'fs'
 Backbone = require 'backbone'
 { fabricate } = require 'antigravity'
 artists = require './fixture.coffee'
+Helpers = require '../../../helpers.coffee'
 
 render = (templateName) ->
   filename = path.resolve __dirname, "../templates/#{templateName}.jade"
@@ -26,6 +27,7 @@ describe 'Artwork artist templates -', ->
         artwork: @artwork
         sd: {}
         asset: (->)
+        helpers: Helpers
         _: _
       )
 
@@ -49,6 +51,10 @@ describe 'Artwork artist templates -', ->
 
     it 'should display artists - plural', ->
       @$('.artwork-artist-module__section-title').text().should.equal 'About the Artists'
+
+    it 'displays exhibition history', ->
+      @$('.artwork-artist-module__content__exhibition-highlights__item__date').first().text().should.equal '2016'
+      @$('.artwork-artist-module__content__exhibition-highlights__item__text').last().text().should.equal 'A Warhol Show, The Goog'
 
   describe 'artist with one artwork', ->
     beforeEach ->

--- a/apps/artwork/components/artist/test/view.coffee
+++ b/apps/artwork/components/artist/test/view.coffee
@@ -7,6 +7,7 @@ CurrentUser = require '../../../../../models/current_user'
 { fabricate, fabricate2 } = require 'antigravity'
 { resolve } = require 'path'
 artists = require './fixture.coffee'
+Helpers = require '../../../helpers.coffee'
 
 describe 'ArtworkArtistView', ->
 
@@ -27,6 +28,7 @@ describe 'ArtworkArtistView', ->
       sd: ARTWORK: @artwork
       _: _
       asset: (->)
+      helpers: Helpers
     }, =>
       ArtworkArtistView = rewire '../view.coffee'
 

--- a/apps/artwork/helpers.coffee
+++ b/apps/artwork/helpers.coffee
@@ -1,0 +1,10 @@
+{ groupBy, sortBy } = require 'underscore'
+
+module.exports =
+  groupBy: groupBy
+
+  sortExhibitions: (shows) ->
+    sortBy(shows, 'start_at').reverse()
+
+  date: (field) ->
+    moment(new Date field)

--- a/apps/artwork/helpers.coffee
+++ b/apps/artwork/helpers.coffee
@@ -1,4 +1,5 @@
 { groupBy, sortBy } = require 'underscore'
+moment = require 'moment'
 
 module.exports =
   groupBy: groupBy

--- a/apps/artwork/routes.coffee
+++ b/apps/artwork/routes.coffee
@@ -2,6 +2,7 @@
 qs = require 'qs'
 metaphysics = require '../../lib/metaphysics'
 { METAPHYSICS_ENDPOINT, CURRENT_USER } = require('sharify').data
+Helpers = require './helpers'
 
 query = (user) -> """
   query artwork($id: String!) {
@@ -75,6 +76,7 @@ query = (user) -> """
         href
         counts {
           artworks
+          partner_shows
         }
       }
       #{require('./components/bid/query.coffee')}
@@ -98,6 +100,7 @@ query = (user) -> """
       res.locals.artwork = data.artwork
       res.locals.sd.ARTWORK = data.artwork
       res.locals.sd.SEADRAGON_URL = res.locals.asset('/assets/openseadragon.js')
+      res.locals.helpers = Helpers
       res.render 'index'
     .catch next
 

--- a/config.coffee
+++ b/config.coffee
@@ -53,7 +53,7 @@ module.exports =
   API_REQUEST_TIMEOUT: 5000
   FORCE_URL: 'https://www.artsy.net'
   PREDICTION_URL: 'https://live.artsy.net'
-  METAPHYSICS_ENDPOINT: 'https://metaphysics-production.artsy.net'
+  METAPHYSICS_ENDPOINT: 'http://localhost:5001'
   DISABLE_IMAGE_PROXY: false
   IMAGE_PROXY: 'GEMINI'
   GEMINI_CLOUDFRONT_URL: 'https://d7hftxdivxxvm.cloudfront.net'

--- a/config.coffee
+++ b/config.coffee
@@ -53,7 +53,7 @@ module.exports =
   API_REQUEST_TIMEOUT: 5000
   FORCE_URL: 'https://www.artsy.net'
   PREDICTION_URL: 'https://live.artsy.net'
-  METAPHYSICS_ENDPOINT: 'http://localhost:5001'
+  METAPHYSICS_ENDPOINT: 'https://metaphysics-production.artsy.net'
   DISABLE_IMAGE_PROXY: false
   IMAGE_PROXY: 'GEMINI'
   GEMINI_CLOUDFRONT_URL: 'https://d7hftxdivxxvm.cloudfront.net'


### PR DESCRIPTION
This adds an 'Exhibition History/Exhibition Highlights' expandable section on the artwork page, and shows the 5 highlights (if > 16 shows in total), or shows the 15 (or less) shows grouped by 'Group', 'Solo', etc.

<img width="314" alt="screen shot 2016-10-10 at 4 20 44 pm" src="https://cloud.githubusercontent.com/assets/1457859/19249848/83f7e64e-8f05-11e6-9c73-99163053a9ec.png">

Closes https://github.com/artsy/microgravity-private/issues/1472
