### PR TITLE
@eessex: Add muted and playsinline attrs to hero background video on articles

### DIFF
--- a/components/article/templates/fullscreen.jade
+++ b/components/article/templates/fullscreen.jade
@@ -2,7 +2,7 @@
   if article.get('hero_section').background_url
     .article-fullscreen-container
       .article-fullscreen-overlay
-      video.article-fullscreen-video-player( src=article.get('hero_section').background_url, autoplay=true, controls=false, loop=true)
+      video.article-fullscreen-video-player( src=article.get('hero_section').background_url, autoplay=true, controls=false, loop=true, muted=true, playsinline=true)
   else if article.get('hero_section').background_image_url
     .article-fullscreen-container
       .article-fullscreen-overlay


### PR DESCRIPTION
The editorial team is trying to ship an email blast for this article https://www.artsy.net/article/artsy-editorial-why-i-consider-burning-man-the-greatest-cultural-movement-of-our-time and they noticed on the new iOS Safari that the background video was paused with a play button. I believe iOS 10 brought new restrictions/features around this—namely the `muted` and `playsinline` attributes needed to be added. More reading https://webkit.org/blog/6784/new-video-policies-for-ios/
