### PR TITLE
Makes image tappable in Current Fairs

### DIFF
--- a/apps/art_fairs/index.styl
+++ b/apps/art_fairs/index.styl
@@ -81,7 +81,7 @@
     overflow hidden
     text-overflow ellipsis
 
-  .fairs-link::after
+  .art-fairs--fair-details::after
     font-family 'artsy-icons'
     content "\e607"
     font-size 24px

--- a/apps/art_fairs/templates/fair-details.jade
+++ b/apps/art_fairs/templates/fair-details.jade
@@ -1,10 +1,9 @@
 .art-fairs--fair-details.past-art-fairs--border-bottom
-  a.fairs-link(href=fair.href)
-    .fair-logo
-      if fair.profile && fair.profile.icon
-        img(src="#{fair.profile.icon.url}")
+  .fair-logo
+    if fair.profile && fair.profile.icon
+      img(src="#{fair.profile.icon.url}")
 
-    .fair-details
-      h5.fair-name= fair.name
-      p.fair-content.fair-content__location= Helpers.cityStateAndCountry(fair.location)
-      p.fair-content.fair-content__dates= Helpers.formatDates(fair)
+  .fair-details
+    h5.fair-name= fair.name
+    p.fair-content.fair-content__location= Helpers.cityStateAndCountry(fair.location)
+    p.fair-content.fair-content__dates= Helpers.formatDates(fair)

--- a/apps/art_fairs/templates/index.jade
+++ b/apps/art_fairs/templates/index.jade
@@ -26,9 +26,9 @@ block content
         if currentFairs
           for fair in currentFairs
             .current-art-fairs
-              a(href=fair.href)
+              a.fairs-link(href=fair.href)
                 .current-art-fairs__image(style="background-image: url(#{fair.image.url})")
-              include fair-details
+                include fair-details
 
       .avant-garde-tabs-list(data-list="upcoming" class= currentFairs && currentFairs.length ? '' : 'avant-garde-tabs-list--active')
         if upcomingFairs

--- a/apps/art_fairs/templates/index.jade
+++ b/apps/art_fairs/templates/index.jade
@@ -26,7 +26,8 @@ block content
         if currentFairs
           for fair in currentFairs
             .current-art-fairs
-              .current-art-fairs__image(style="background-image: url(#{fair.image.url})")
+              a(href=fair.href)
+                .current-art-fairs__image(style="background-image: url(#{fair.image.url})")
               include fair-details
 
       .avant-garde-tabs-list(data-list="upcoming" class= currentFairs && currentFairs.length ? '' : 'avant-garde-tabs-list--active')

--- a/apps/art_fairs/templates/past-fairs.jade
+++ b/apps/art_fairs/templates/past-fairs.jade
@@ -1,6 +1,6 @@
 for fair in pastFairs
-  //- include fair
-  include fair-details
+  a.fairs-link(href=fair.href)
+    include fair-details
 if remainingPastFairs.length > 0
   button#paginate-past-fairs.avant-garde-box-button.avant-garde-box-button-white( href='#', data-state='ok' )
     | Load More


### PR DESCRIPTION
Related to #33 

Wrapped the image with a link: 

``` html
<a href="/kiaf-2016">
  <div style="background-image: url(https://d32dm0rphc51dk.cloudfront.net/FVY-tCi7_MEtpHMJK50Vjg/wide.jpg)" class="current-art-fairs__image">
  </div>
</a>
```

However, there is a tiny space between the image and the text that is not tappable (green area):

![image](https://cloud.githubusercontent.com/assets/1916041/19333854/67fbca80-90ce-11e6-93dc-d87b4d8d6b9b.png)

Considered wrapping the whole thing with a link:
![image](https://cloud.githubusercontent.com/assets/1916041/19333886/a1401c38-90ce-11e6-9b0e-9f9cbf4a97d6.png)

But it was not clear to me if `current-art-fairs` contains only one fair or if it's wrapping multiple fairs 😅 (also feels that wrapping everything would cause an `a` tag to be spawned for each element, which looks weird).

Anyway, is this helpful? Any feedback?
