### PR TITLE
@sweir27 move bid status message into mixin component, fix tests

### DIFF
--- a/apps/artwork/components/bid/index.coffee
+++ b/apps/artwork/components/bid/index.coffee
@@ -8,7 +8,7 @@ query = """
   query artwork($id: String!, $sale_id: String!) {
     me {
       lot_standing(artwork_id: $id, sale_id: $sale_id) {
-        is_highest_bidder
+        is_leading_bidder
       }
     }
     artwork(id: $id) {

--- a/apps/artwork/components/bid/index.styl
+++ b/apps/artwork/components/bid/index.styl
@@ -26,9 +26,6 @@
       color reserve-yellow-color
     &__is-losing p
       color red-color
-    &__increase-bid
-      clear both
-      color gray-darker-color
     &__arrow-up, &__arrow-down
       position relative
       fill currentColor

--- a/apps/artwork/components/bid/index.styl
+++ b/apps/artwork/components/bid/index.styl
@@ -6,34 +6,40 @@
 .artwork-auction-bid-module__bid-status-amount
   float right
 
-.artwork-auction-bid-module__bid-status-count
-  garamond-size('m-caption', true)
-  color gray-darker-color
-  display inline
-
-.artwork-auction-bid-module__bid-status__users-bid-status
-  display inline-block
-  float right
-  &.highest-bid
-    color green-color
-    .bidder-status-arrow
-      border-bottom-color green-color
-  &.outbid
-    color red-color
-    .bidder-status-arrow
-      border-bottom-color red-color
-      transform rotate(180deg)
-  .user-bid-status-text
+.artwork-auction-bid-module__bid-status__count-user-status
+  .artwork-auction-bid-module__bid-status-count
+    garamond-size('m-caption', true)
+    color gray-darker-color
     display inline
-    margin-right 10px
-    avant-garde-size('s-headline', true)
-  .bidder-status-arrow
-    width 0
-    height 0
-    border-left 6.5px solid transparent
-    border-right 6.5px solid transparent
-    border-bottom 11.5px solid
-    display inline-block
+    float left
+  .bid-status-message
+    p
+      display inline-block
+      float right
+      color red-color
+      avant-garde()
+      avant-garde-size('s-headline', true)
+      margin-top 2px
+    &__is-winning p
+      color green-color
+    &__is-winning-reserve-not-met p
+      color reserve-yellow-color
+    &__is-losing p
+      color red-color
+    &__increase-bid
+      clear both
+      color gray-darker-color
+    &__arrow-up, &__arrow-down
+      position relative
+      fill currentColor
+      padding-left 3px
+      svg
+        margin-left 4px
+        height .8em
+    &__arrow-up svg
+      transform rotate(180deg)
+    &__arrow-down svg
+      transform rotate(0deg)
 
 .auction-avant-garde-black-button
   avant-garde-size('body', true)

--- a/apps/artwork/components/bid/templates/bid.jade
+++ b/apps/artwork/components/bid/templates/bid.jade
@@ -1,16 +1,17 @@
 include ./bid_status_message.jade
+- bidderPositions = artwork.auction.sale_artwork.counts.bidder_positions
 .artwork-auction-bid-module__bid-status
-  .artwork-auction-bid-module__bid-status-title= artwork.auction.sale_artwork.counts.bidder_positions > 0 ? 'Current Bid:' : 'Starting Bid:'
+  .artwork-auction-bid-module__bid-status-title= bidderPositions > 0 ? 'Current Bid:' : 'Starting Bid:'
   .artwork-auction-bid-module__bid-status-amount
     = artwork.auction.sale_artwork.current_bid.amount
 .artwork-auction-bid-module__bid-status__count-user-status
   .artwork-auction-bid-module__bid-status-count
-    if artwork.auction.sale_artwork.counts.bidder_positions > 0
-      | #{artwork.auction.sale_artwork.counts.bidder_positions} Bids
+    if bidderPositions > 0
+      | #{bidderPositions} #{bidderPositions === 1 ? 'Bid' : 'Bids'}
     if artwork.auction.sale_artwork.reserve_status == 'reserve_met'
-      span , Reserve met
-    else if reserveNotMet
-      span , Reserve not met
+      span #{bidderPositions > 0 ? ', ' : '' }Reserve met
+    else if artwork.auction.sale_artwork.reserve_status == 'reserve_not_met'
+      span #{bidderPositions > 0 ? ', ' : '' }Reserve not met
     //- TODO: https://github.com/artsy/auctions/issues/124
     //- else
     //-   span No reserve

--- a/apps/artwork/components/bid/templates/bid.jade
+++ b/apps/artwork/components/bid/templates/bid.jade
@@ -1,3 +1,4 @@
+include ./bid_status_message.jade
 .artwork-auction-bid-module__bid-status
   .artwork-auction-bid-module__bid-status-title= artwork.auction.sale_artwork.counts.bidder_positions > 0 ? 'Current Bid:' : 'Starting Bid:'
   .artwork-auction-bid-module__bid-status-amount
@@ -8,17 +9,10 @@
       | #{artwork.auction.sale_artwork.counts.bidder_positions} Bids
     if artwork.auction.sale_artwork.reserve_status == 'reserve_met'
       span , Reserve met
-    else if artwork.auction.sale_artwork.reserve_status == 'reserve_not_met'
+    else if reserveNotMet
       span , Reserve not met
     //- TODO: https://github.com/artsy/auctions/issues/124
     //- else
     //-   span No reserve
   if bidder && bidder.lot_standing && typeof window !== 'undefined'
-    if bidder.lot_standing.is_highest_bidder
-      .artwork-auction-bid-module__bid-status__users-bid-status.highest-bid
-        .user-bid-status-text Highest Bid
-        .bidder-status-arrow
-    else
-      .artwork-auction-bid-module__bid-status__users-bid-status.outbid
-        .user-bid-status-text Outbid
-        .bidder-status-arrow
+    +bidStatusMessage(bidder.lot_standing, artwork.auction.sale_artwork)

--- a/apps/artwork/components/bid/templates/bid_status_message.jade
+++ b/apps/artwork/components/bid/templates/bid_status_message.jade
@@ -1,0 +1,22 @@
+mixin bidStatusMessage(lotStanding, saleArtwork)
+  - leadingBidder = lotStanding.is_leading_bidder
+  - reserveNotMet = saleArtwork.reserve_status === 'reserve_not_met'
+  .bid-status-message
+    if leadingBidder && !reserveNotMet
+      .bid-status-message__is-winning
+        p Highest Bidder
+          i.bid-status-message__arrow-up
+            include ../../../public/icons/bid-status-arrow.svg
+    else
+      if leadingBidder && reserveNotMet
+        .bid-status-message__is-winning-reserve-not-met
+          p Highest Bidder, Reserve not met
+            i.bid-status-message__arrow-up
+              include ../../../public/icons/bid-status-arrow.svg
+      else
+        .bid-status-message__is-losing
+          p Outbid
+            i.bid-status-message__arrow-down
+              include ../../../public/icons/bid-status-arrow.svg
+      .bid-status-message__increase-bid
+        | Increase your max bid to win the lot

--- a/apps/artwork/components/bid/templates/bid_status_message.jade
+++ b/apps/artwork/components/bid/templates/bid_status_message.jade
@@ -10,7 +10,7 @@ mixin bidStatusMessage(lotStanding, saleArtwork)
     else
       if leadingBidder && reserveNotMet
         .bid-status-message__is-winning-reserve-not-met
-          p Highest Bidder, Reserve not met
+          p Highest Bidder
             i.bid-status-message__arrow-up
               include ../../../public/icons/bid-status-arrow.svg
       else
@@ -18,5 +18,3 @@ mixin bidStatusMessage(lotStanding, saleArtwork)
           p Outbid
             i.bid-status-message__arrow-down
               include ../../../public/icons/bid-status-arrow.svg
-      .bid-status-message__increase-bid
-        | Increase your max bid to win the lot

--- a/apps/artwork/components/bid/test/template.coffee
+++ b/apps/artwork/components/bid/test/template.coffee
@@ -56,6 +56,55 @@ describe 'Artwork bid templates', ->
     it 'displays an enabled bid button', ->
       @$('.auction-avant-garde-black-button').should.not.containEql 'disabled'
       @$('.auction-avant-garde-black-button').text().should.equal 'Bid'
+    describe 'bid-status-count formatting', ->
+      it 'displays singular "1 Bid" for one bid', ->
+        @artwork.auction.sale_artwork.counts.bidder_positions = 1
+        @html = render('index')(
+          artwork: @artwork
+          me: @me
+          sd: {}
+          asset: (->)
+          _: _
+        )
+        @$ = cheerio.load(@html)
+        @$('.artwork-auction-bid-module__bid-status-count').text().should.containEql '1 Bid'
+
+      it 'displays plural "x Bids" for plural bids', ->
+        @artwork.auction.sale_artwork.counts.bidder_positions = 7
+        @html = render('index')(
+          artwork: @artwork
+          me: @me
+          sd: {}
+          asset: (->)
+          _: _
+        )
+        @$ = cheerio.load(@html)
+        @$('.artwork-auction-bid-module__bid-status-count').text().should.containEql '7 Bids'
+
+      it 'displays reserve status correctly with bids', ->
+        @artwork.auction.sale_artwork.counts.bidder_positions = 1
+        @html = render('index')(
+          artwork: @artwork
+          me: @me
+          sd: {}
+          asset: (->)
+          _: _
+        )
+        @$ = cheerio.load(@html)
+        @$('.artwork-auction-bid-module__bid-status-count').text().should.containEql ', Reserve not met'
+      
+      it 'displays reserve status correctly with no bids - reserve message only', ->
+        @artwork.auction.sale_artwork.counts.bidder_positions = 0
+        @artwork.auction.sale_artwork.reserve_status = 'reserve_met'
+        @html = render('index')(
+          artwork: @artwork
+          me: @me
+          sd: {}
+          asset: (->)
+          _: _
+        )
+        @$ = cheerio.load(@html)
+        @$('.artwork-auction-bid-module__bid-status-count').text().should.equal 'Reserve met'
 
   describe 'bidder with bidder positions', ->
 
@@ -84,7 +133,6 @@ describe 'Artwork bid templates', ->
       )
       @$ = cheerio.load(@html)
       @$('.bid-status-message p').text().should.match /^Highest Bidder\n/
-      @$('.bid-status-message__increase-bid').should.not.exist
 
     it 'displays user bidder status - leading bidder & reserve not met', ->
       @artwork.auction.sale_artwork.reserve_status = 'no.'
@@ -98,8 +146,7 @@ describe 'Artwork bid templates', ->
         _: _
       )
       @$ = cheerio.load(@html)
-      @$('.bid-status-message p').text().should.containEql 'Highest Bidder, Reserve not met'
-      @$('.bid-status-message__increase-bid').text().should.equal 'Increase your max bid to win the lot'
+      @$('.bid-status-message__is-winning-reserve-not-met').text().should.containEql 'Highest Bidder'
 
     it 'displays user bidder status - outbid, reserve not met', ->
       me =  { id: 'my unique id', lot_standing: { is_leading_bidder: false } }
@@ -112,7 +159,6 @@ describe 'Artwork bid templates', ->
       )
       @$ = cheerio.load(@html)
       @$('.bid-status-message p').text().should.containEql 'Outbid'
-      @$('.bid-status-message__increase-bid').text().should.equal 'Increase your max bid to win the lot'
 
     it 'displays user bidder status - outbid, reserve does not apply', ->
       me =  { id: 'my unique id', lot_standing: { is_leading_bidder: false } }
@@ -125,7 +171,6 @@ describe 'Artwork bid templates', ->
       )
       @$ = cheerio.load(@html)
       @$('.bid-status-message p').text().should.containEql 'Outbid'
-      @$('.bid-status-message__increase-bid').text().should.equal 'Increase your max bid to win the lot'
 
     it 'displays correct bidding amount label with bids', ->
       me =  { id: 'my unique id', lot_standing: { is_leading_bidder: false } }
@@ -218,5 +263,5 @@ describe 'Artwork bid templates', ->
       @$('.artwork-auction-bid-module__bid-status-title').text().should.equal 'Starting Bid:'
 
 
-    xit 'do not display number of bids', ->
+    it 'do not display number of bids', ->
       @$('.artwork-auction-bid-module__bid-status-count').text().should.equal 'Reserve not met'

--- a/apps/artwork/public/icons/bid-status-arrow.svg
+++ b/apps/artwork/public/icons/bid-status-arrow.svg
@@ -1,0 +1,4 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8.14 7.05">
+  <title>arrow</title>
+  <polygon class="cls-1" points="4.07 7.05 0 0 8.14 0 4.07 7.05"/>
+</svg>

--- a/components/stylus_lib/index.styl
+++ b/components/stylus_lib/index.styl
@@ -19,6 +19,8 @@ dark-gray-text-color = #666
 golden-ratio-small-percent = 38%
 light-gray-text-color = rgb(125, 125, 125)
 note-yellow-bg-color = #FEFFD8
+reserve-yellow-color = #F1AF1B
+
 
 json('../../node_modules/artsy-ezel-components/stylus_lib/colors.json')
 


### PR DESCRIPTION
It wasn't really necessary, but i'd just done a jade mixin with @craigspaeth yesterday in force so i wanted to reproduce it once myself. i can move it out into the bid.jade template if we prefer.

Also, there were several tests that seemed nested in the wrong scenarios or redundant, so i deleted them. i'll comment below.

After talking with @katarinabatina i updated this layout to differ slightly from force- there is not additional 'reserve not met' message in the yellow portion of the bid status text, and 'x bid(s)' is properly pluralized.
![image](https://cloud.githubusercontent.com/assets/9088720/19494624/fe2c314c-954d-11e6-9a47-0f9ae8241858.png)

![image](https://cloud.githubusercontent.com/assets/9088720/19494638/10e11122-954e-11e6-8acf-a638b23d1210.png)
![image](https://cloud.githubusercontent.com/assets/9088720/19494688/4d080e6c-954e-11e6-8325-9377425ef927.png)
![image](https://cloud.githubusercontent.com/assets/9088720/19494716/6bf6f748-954e-11e6-82d8-4aeaeecf1d90.png)

Here is the before- i do think this is a different green than in force: 
![image](https://cloud.githubusercontent.com/assets/9088720/19494751/910f86bc-954e-11e6-869e-d3bea64760cc.png)
