### PR TITLE
@xtina-starr => Show partners featured bio on their artwork page if they have one

### DIFF
--- a/apps/artwork/components/artist/index.styl
+++ b/apps/artwork/components/artist/index.styl
@@ -86,6 +86,9 @@
 .aama-fair-shows
   margin-bottom 20px
 
+.aama-biography-credit
+  font-style italic
+
 .aama-article
   a.aama-article-link
     border-top-style none

--- a/apps/artwork/components/artist/query.coffee
+++ b/apps/artwork/components/artist/query.coffee
@@ -21,7 +21,12 @@ module.exports = """
       }
     }
     bio
-    biography: blurb(format: HTML)
+    blurb(format: HTML)
+    biography_blurb(format: HTML, partner_bio: true) {
+      text
+      credit
+      partner_id
+    }
     articles {
       title
       href

--- a/apps/artwork/components/artist/templates/index.jade
+++ b/apps/artwork/components/artist/templates/index.jade
@@ -47,9 +47,15 @@ if artists.length
             if artist.bio
               a.aama-overview-title.js-aama-accordion-link.is-active(data-id="overview-#{artist.id}") Overview
               .aama-tab-content.js-aama-content.is-active(data-id="overview-#{artist.id}")  #{artist.bio.replace('born', 'b.')}
-            if artist.biography
+            if artist.biography_blurb && artist.biography_blurb.partner_id == artwork.partner.id
               a.aama-biography-title.js-aama-accordion-link(data-id="biography-#{artist.id}") Biography
-              .aama-tab-content.js-aama-content(data-id="biography-#{artist.id}")!= artist.biography
+              .aama-tab-content.js-aama-content(data-id="biography-#{artist.id}")
+                != artist.biography_blurb.text
+                if artist.biography_blurb.credit
+                  .aama-biography-credit &mdash; #{artist.biography_blurb.credit}
+            else if artist.blurb
+              a.aama-biography-title.js-aama-accordion-link(data-id="biography-#{artist.id}") Biography
+              .aama-tab-content.js-aama-content(data-id="biography-#{artist.id}")!= artist.blurb
 
         .artwork-artist-module__accordion
           if artist.exhibition_highlights && artist.exhibition_highlights.length <= 15

--- a/apps/artwork/components/artist/test/fixture.coffee
+++ b/apps/artwork/components/artist/test/fixture.coffee
@@ -45,7 +45,12 @@ module.exports =
         }
       ],
       bio: 'Born 1970, New York, New York, and based in Paris'
-      biography: "This is Picasso's bio.",
+      blurb: "This is Picasso's bio.",
+      biography_blurb: {
+        text: 'Picasso was a cat.'
+        credit: 'Submitted by Catty Partner.'
+        partner_id: 'catty-partner'
+      }
       exhibition_highlights: [
         {
           href: "/show/retrospective"

--- a/apps/artwork/components/artist/test/template.coffee
+++ b/apps/artwork/components/artist/test/template.coffee
@@ -19,6 +19,25 @@ describe 'Artwork artist templates -', ->
   beforeEach ->
     @artwork = fabricate 'artwork'
 
+  describe 'artwork with a featured bio submitted by that partner', ->
+    beforeEach ->
+      @artwork.artists = artists
+      @artwork.partner = { id: 'catty-partner' }
+      @html = render('index')(
+        artwork: @artwork
+        sd: {}
+        asset: (->)
+        helpers: Helpers
+        _: _
+      )
+
+      @$ = cheerio.load(@html)
+
+    it 'should display artist bio', ->
+      text = @$('.aama-tab-content').filter("[data-id=biography-#{artists[0].id}]").first().text()
+      text.should.containEql 'Picasso was a cat'
+      text.should.containEql 'Submitted by Catty Partner'
+
   describe 'artwork with artist', ->
     beforeEach ->
       @artwork.artists = artists


### PR DESCRIPTION
MG version of https://github.com/artsy/force/pull/312

Closes https://github.com/artsy/microgravity/issues/40

Basically, if there is a featured bio then we want to display that on that partner's artwork pages, all other cases we want to just keep displaying the Artsy bio.
