### PR TITLE
@xtina-starr => Support partner featured bio on artist biography page

### DIFF
--- a/apps/artist/index.styl
+++ b/apps/artist/index.styl
@@ -54,6 +54,9 @@
 #artist-biography-page
   margin-bottom 20px
 
+.artist-biography-page-credit
+  font-style italic
+
 #artist-content
   position relative
 

--- a/apps/artist/routes.coffee
+++ b/apps/artist/routes.coffee
@@ -22,9 +22,10 @@ module.exports.index = (req, res, next) ->
   artist.fetch
     cache: true
     success: ->
-      res.locals.sd.ARTIST = artist.toJSON()
-      showAuctionLink = artist.get('display_auction_link')
-      res.render 'page', artist: artist, sort: req.query?.sort, showAuctionLink: showAuctionLink
+      artist.maybeFetchAndSetFeaturedBio =>
+        res.locals.sd.ARTIST = artist.toJSON()
+        showAuctionLink = artist.get('display_auction_link')
+        res.render 'page', artist: artist, sort: req.query?.sort, showAuctionLink: showAuctionLink
     error: res.backboneError
 
 module.exports.biography = (req, res, next) ->

--- a/apps/artist/routes.coffee
+++ b/apps/artist/routes.coffee
@@ -1,4 +1,21 @@
 Artist = require '../../models/artist'
+metaphysics = require '../../lib/metaphysics'
+
+query = """
+  query artist($id: String!) {
+    artist(id: $id) {
+      name
+      id
+      hometown
+      years
+      biography_blurb(format: HTML) {
+        text
+        credit
+      }
+    }
+  }
+
+"""
 
 module.exports.index = (req, res, next) ->
   artist = new Artist id: req.params.id
@@ -11,13 +28,11 @@ module.exports.index = (req, res, next) ->
     error: res.backboneError
 
 module.exports.biography = (req, res, next) ->
-  artist = new Artist id: req.params.id
-  artist.fetch
-    cache: true
-    success: ->
-      res.locals.sd.ARTIST = artist.toJSON()
-      res.render 'biography', artist: artist
-    error: res.backboneError
+   metaphysics query: query, variables: req.params, req: req
+    .then (data) ->
+      res.locals.sd.ARTIST = data.artist
+      res.render 'biography', artist: data.artist
+    .catch next
 
 module.exports.auctionResults = (req, res, next) ->
   artist = new Artist id: req.params.id

--- a/apps/artist/templates/biography.jade
+++ b/apps/artist/templates/biography.jade
@@ -3,4 +3,8 @@ extends ../../../components/layout/templates/main
 block content
   include header
   #artist-biography-page.main-side-margin
-    != artist.mdToHtml('blurb')
+    if artist.biography_blurb && artist.biography_blurb.text
+      != artist.biography_blurb.text
+      if artist.biography_blurb.credit
+        .artist-biography-page-credit
+          | &mdash; #{artist.biography_blurb.credit}

--- a/apps/artist/templates/header.jade
+++ b/apps/artist/templates/header.jade
@@ -1,7 +1,11 @@
+-var hometown = artist.hometown || artist.get('hometown')
+-var years = artist.years || artist.get('years')
+-var name = artist.name || artist.get('name')
+
 header#artist-page-header
-  h1.artist-page-large-header.avant-garde-header-center= artist.get('name')
+  h1.artist-page-large-header.avant-garde-header-center= name
   h2
-    = artist.get('hometown')
-    if artist.get('years') && artist.get('hometown')
+    = hometown
+    if years && hometown
       | , 
-    = artist.get('years')
+    = hometown

--- a/apps/artist/templates/header.jade
+++ b/apps/artist/templates/header.jade
@@ -8,4 +8,4 @@ header#artist-page-header
     = hometown
     if years && hometown
       | , 
-    = hometown
+    = years

--- a/apps/artist/test/templates.coffee
+++ b/apps/artist/test/templates.coffee
@@ -63,7 +63,8 @@ describe 'Biography', ->
   beforeEach ->
     @locals = { sd: {}, asset: (->) }
 
-  it 'renders the bio if there is a blurb', ->
-    @locals.artist = new Artist fabricate('artist', blurb: 'Bitty was a cat.')
+  it 'renders the bio and credit if there is one', ->
+    @locals.artist = { hometown: 'Heaven', years: '1995 - 2014', name: 'Bitty', id: 'bitty', biography_blurb: { credit: 'Submitted by Matt', text: 'Bitty was a cat.' } }
     render('biography')(@locals).should.containEql 'Bitty was a cat.'
+    render('biography')(@locals).should.containEql 'Submitted by Matt'
   

--- a/models/artist.coffee
+++ b/models/artist.coffee
@@ -23,6 +23,16 @@ module.exports = class Artist extends Backbone.Model
   hasImage: (size = 'tall') ->
     size in (@get('image_versions') || [])
 
+  maybeFetchAndSetFeaturedBio: (cb = ->) ->
+    return cb() if @get('blurb')
+    partner_artists = new Backbone.Collection()
+    partner_artists.url = "#{sd.API_URL}/api/v1/artist/#{@get('id')}/partner_artists?size=1&featured=true"
+    partner_artists.fetch
+      success: (featured) =>
+        return cb() unless featured.length and featured.models[0].has('biography')
+        @set 'blurb', featured.models[0].get('biography')
+        cb()
+
   fetchArtworks: (options = {}) ->
     artworks = new Artworks
     artworks.url = @url() + '/artworks'

--- a/test/models/artist.coffee
+++ b/test/models/artist.coffee
@@ -18,6 +18,25 @@ describe 'Artist', ->
       @artist.set image_url: 'foo/bar/:version.jpg'
       @artist.imageUrl().should.equal 'foo/bar/medium.jpg'
 
+  describe '#maybeFetchAndSetFeaturedBio', ->
+
+    it 'calls the callback and doesnt change the blurb if there is a blurb', ->
+      @artist.set(blurb: 'original blurb')
+      cb = sinon.stub()
+      @artist.maybeFetchAndSetFeaturedBio cb
+      Backbone.sync.args.length.should.equal 0
+      @artist.get('blurb').should.equal 'original blurb'
+      cb.called.should.be.ok()
+
+    it 'sets the featured partner bio and calls the callback if there is no blurb', ->
+      @artist.unset 'blurb'
+      cb = sinon.stub()
+      @artist.maybeFetchAndSetFeaturedBio cb
+      Backbone.sync.args[0][2].success [{ biography: 'featured blurb' }]
+      Backbone.sync.args[0][1].url.should.containEql 'partner_artists?size=1&featured=true'
+      cb.called.should.be.ok()
+      @artist.get('blurb').should.equal 'featured blurb'
+
   describe '#fetchArtworks', ->
 
     it 'fetches the artists artworks', (done) ->


### PR DESCRIPTION
This updates the biography page for an artist to support featured bios, through Metaphysics. MG version of https://github.com/artsy/force/pull/314.

Pretty straightforward, safe to merge. Next up, trying to figure out how to 'know' whether to render the bio tab on the main artist page, in the event of no Artsy bio but an existing featured partner bio. Unless the whole page is rewritten to use Metaphysics...I may have to add that call :(
