### PR TITLE
@kanaabe: Remove unused handling of artworks' comparable sales

### DIFF
--- a/models/artwork.coffee
+++ b/models/artwork.coffee
@@ -78,18 +78,6 @@ module.exports = class Artwork extends Backbone.Model
     else
       @get('partner').name
 
-  fetchAuctionResults: (options = {}) ->
-    new Backbone.Collection().fetch _.extend options,
-      url: "#{sd.API_URL}/api/v1/artwork/#{@get 'id'}/comparable_sales"
-
-  canShowAuctionResults: (options = {}) ->
-    new Backbone.Collection().fetch
-      url: "#{sd.API_URL}/api/v1/site_features"
-      success: (features) =>
-        options.success features.findWhere(id: 'auction-results')?.get('enabled') and
-                        @get('comparables_count') > 0 and @get('category') isnt 'Architecture'
-      error: options.error
-
   fetchRelatedSales: (options = {}) ->
     new Backbone.Collection(null,
       model: Sale

--- a/test/models/artwork.coffee
+++ b/test/models/artwork.coffee
@@ -128,30 +128,6 @@ describe 'Artwork', ->
       Backbone.sync.args[0][2].success [fabricate 'sale', is_auction: true, name: 'Awesome Sale']
       Backbone.sync.args[1][2].success fabricate 'sale_artwork', opening_bid_cents: 100000
 
-  describe '#fetchAuctionResults', ->
-
-    it 'fetches the auction results for that artwork', (done) ->
-      @artwork.fetchAuctionResults success: (results) ->
-        results.first().get('estimate_text').should.equal '$100,000'
-        done()
-      Backbone.sync.args[0][2].success [fabricate 'auction_result', estimate_text: '$100,000']
-
-  describe '#canShowAuctionResults', ->
-
-    it 'returns true if site feature enabled', (done) ->
-      @artwork.set comparables_count: 2, category: 'Painting'
-      @artwork.canShowAuctionResults success: (show) ->
-        show.should.be.ok()
-        done()
-      Backbone.sync.args[0][2].success [{ id: 'auction-results', enabled: true }]
-
-    it 'returns false if in Architecture', (done) ->
-      @artwork.set comparables_count: 2, category: 'Architecture'
-      @artwork.canShowAuctionResults success: (show) ->
-        show.should.not.be.ok()
-        done()
-      Backbone.sync.args[0][2].success [{ id: 'auction-results', enabled: true }]
-
   describe '#hasMoreInfo', ->
 
     it 'returns true if the artwork has more info to display and false otherwise', ->


### PR DESCRIPTION
We no longer serve the artwork/:id/auction-results pages that formerly listed "comparable" auction results for an artwork. This removes the related handling. I may remove the API endpoints altogether next.