### PR TITLE
@craigspaeth => sort auctions api response by end_at

### DIFF
--- a/apps/auctions/routes.coffee
+++ b/apps/auctions/routes.coffee
@@ -11,11 +11,9 @@ eligibleFilter = _.partial _.filter, _, ((sale) ->
 
 module.exports.index = (req, res) ->
   sales = new Sales
-  sales.comparator = (sale) ->
-    -(Date.parse(sale.get 'end_at'))
   sales.fetch
     cache: true
-    data: is_auction: true, published: true, size: 20, sort: '-created_at'
+    data: is_auction: true, published: true, size: 20, sort: '-end_at'
     success: (collection, response, options) ->
       # Fetch artworks for the sale
       Q.allSettled(sales.map (sale) ->

--- a/apps/auctions/test/routes.coffee
+++ b/apps/auctions/test/routes.coffee
@@ -26,7 +26,7 @@ describe 'Auctions routes', ->
     it 'fetches the relevant auction data and renders the index template', (done) ->
       routes.index {}, @res
       Backbone.sync.args[0][1].url.should.containEql '/api/v1/sales'
-      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 20, sort: '-created_at'
+      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 20, sort: '-end_at'
       Backbone.sync.args[0][2].success(@sales)
       Backbone.sync.callCount.should.equal 5
       Backbone.sync.args[1][1].url().should.containEql '/api/v1/sale/invalid-sale/sale_artworks'
@@ -56,7 +56,7 @@ describe 'Auctions routes', ->
     it 'sorts the open auctions by live_start_at or end_at', (done) ->
       routes.index {}, @res
       Backbone.sync.args[0][1].url.should.containEql '/api/v1/sales'
-      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 20, sort: '-created_at'
+      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 20, sort: '-end_at'
       Backbone.sync.args[0][2].success(@sales)
       Backbone.sync.callCount.should.equal 5
       Backbone.sync.args[1][1].url().should.containEql '/api/v1/sale/invalid-sale/sale_artworks'


### PR DESCRIPTION
We have so many auctions, that just sorting by `-created_at` and limiting `size: 20` may cause us to miss some auctions that are upcoming!

We were sorting the sales by `end_at` anyways-- this PR just replaces the `-created_at` sort with an `-end_at` sort, which is also supported by the API.

(Note that if we end up with > 20 open sales at once, this code will also not return some auctions... so I'm leaving this here as reference but also hopefully by then we've implemented new designs!)

cc @devangt 