### PR TITLE
check for presence of floorplan url

### DIFF
--- a/apps/fair_info/templates/index.jade
+++ b/apps/fair_info/templates/index.jade
@@ -9,7 +9,7 @@ block content
         if infoMenu.events
           a(href="/#{sd.PROFILE.id}/info/events") events
         a(target="_blank", href=location.gmapLink()) map
-        if fair.has('floorplan_url')
+        if fair.get('floorplan_url')
           a(href=fair.get('floorplan_url')) floorplan (pdf)
         if infoMenu.programming
           a(href="/#{sd.PROFILE.id}/info/programming") programming


### PR DESCRIPTION
The `floorplan_url` contains an empty string and displaying a link when it shouldn't. Switching to the `get` method to catch the evaluation of an empty string. For more [context](https://artsy.slack.com/archives/help/p1478531265001205).

![screen shot 2016-11-07 at 11 29 36 am](https://cloud.githubusercontent.com/assets/5201004/20065831/8ffb1b44-a4dd-11e6-8b41-f16418643679.png)
