### PR TITLE
@alloy: Make height of marketing modal to 85% of viewport

### DIFF
--- a/components/marketing_signup_modal/index.styl
+++ b/components/marketing_signup_modal/index.styl
@@ -6,6 +6,9 @@ modal-height = 360px
   background black
   position relative
   overflow hidden
+  height 85vh
+  display flex
+  position relative
 
   &-inner
     background black
@@ -16,6 +19,7 @@ modal-height = 360px
     width 100%
     height modal-height
     z-index -1
+    align-self center
 
   &-copy
     garamond-size('l-body', true)

--- a/components/marketing_signup_modal/index.styl
+++ b/components/marketing_signup_modal/index.styl
@@ -1,7 +1,4 @@
-modal-height = 360px
-
 .marketing-signup-modal
-  height modal-height
   z-index 3
   background black
   position relative
@@ -17,7 +14,6 @@ modal-height = 360px
     text-align center
     position fixed
     width 100%
-    height modal-height
     z-index -1
     align-self center
 


### PR DESCRIPTION
@jessekedy [mentioned](https://artsy.slack.com/archives/marketing-ops/p1479823403000271) that it would be ideal to have a full-screen modal, and I noticed that with variable copy length our fixed height would chop off content sometimes. This is somewhat of a compromise to address those issues that makes the modal height based on the viewport so that most of the screen is taken over with just a peak of content below. Related to: https://github.com/artsy/force/issues/365#issuecomment-262343858

![image](https://cloud.githubusercontent.com/assets/555859/20950416/980236f2-bbed-11e6-8ca0-5c5bd21e9096.png)
