### PR TITLE
@craigspaeth: Fix app banner to not prompt Android users

### DIFF
--- a/components/app_banner/app_banner.coffee
+++ b/components/app_banner/app_banner.coffee
@@ -64,7 +64,8 @@ module.exports = class AppBanner
     USER_AGENT?.match('Artsy-Mobile')?
 
   @shouldDisplay: ->
-    USER_AGENT?.match(/(Chrome)/)? and
+    USER_AGENT?.match(/iPhone/i)? and
+    USER_AGENT?.match(/CriOS/i)? and
     not @hasDismissed() and
     not @isEigen() and
     not excluded.check()

--- a/components/app_banner/app_banner.coffee
+++ b/components/app_banner/app_banner.coffee
@@ -54,10 +54,10 @@ module.exports = class AppBanner
     @$el.remove()
     @$content.css marginTop: 0
 
-  seen: ->
+  dismissed: ->
     Cookies.set @cookie, yes, expires: (60 * 60 * 24 * 365)
 
-  @hasSeen: ->
+  @hasDismissed: ->
     Cookies.get(@::cookie)?
 
   @isEigen: ->
@@ -65,6 +65,6 @@ module.exports = class AppBanner
 
   @shouldDisplay: ->
     USER_AGENT?.match(/(Chrome)/)? and
-    not @hasSeen() and
+    not @hasDismissed() and
     not @isEigen() and
     not excluded.check()

--- a/components/app_banner/test/app_banner.coffee
+++ b/components/app_banner/test/app_banner.coffee
@@ -20,24 +20,21 @@ describe 'AppBanner', ->
     $('.app-banner').siblings().attr('id').should.equal 'content'
 
   describe '#shouldDisplay', ->
-    describe 'has not seen, is iOS', ->
+    describe 'has not seen', ->
       beforeEach ->
         @UA = @AppBanner.__get__ 'USER_AGENT'
-        @AppBanner.__set__ 'USER_AGENT', '(Chrome)'
 
       afterEach ->
         @AppBanner.__set__ 'USER_AGENT', @UA
 
-      it 'should return true', ->
+      it 'true when iPhone but not Safari (i.e., Chrome on iOS)', ->
+        @AppBanner.__set__ 'USER_AGENT', 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en-gb) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3'
         @AppBanner.shouldDisplay().should.be.true()
 
-      describe 'is also Eigen', ->
-        beforeEach ->
-          @UA = @AppBanner.__get__ 'USER_AGENT'
-          @AppBanner.__set__ 'USER_AGENT', 'Something something / Artsy-Mobile / I have no idea what the real user agent is'
+      it 'false when Eigen', ->
+        @AppBanner.__set__ 'USER_AGENT', 'Mozilla/5.0 Artsy-Mobile/3.0.3 Eigen/2016.12.02.09/3.0.3 (iPad; iOS 10.1.1; Scale/2.00) AppleWebKit/601.1.46 (KHTML, like Gecko)'
+        @AppBanner.shouldDisplay().should.be.false()
 
-        afterEach ->
-          @AppBanner.__set__ 'USER_AGENT', @UA
-
-        it 'returns false if the user agent is that of Eigen', ->
-          @AppBanner.shouldDisplay().should.be.false()
+      it 'false when iPhone/Safari, where meta tag supersedes this', ->
+        @AppBanner.__set__ 'USER_AGENT', 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
+        @AppBanner.shouldDisplay().should.be.false()

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -17,13 +17,13 @@ curl https://raw.github.com/creationix/nvm/master/install.sh | sh
 Then install the latest node
 
 ````
-nvm install 0.10
+nvm install 6
 ````
 
 Then tell nvm to use the latest version of node by default and to update your PATH
 
 ````
-nvm alias default 0.10
+nvm alias default 6
 ````
 
 ## Install Node Modules


### PR DESCRIPTION
Fixes #71. The prompt to install the iPhone app was _only_ being applied to Android users. IPhone users on recent Safari would instead see the ["smart" app banner](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html). This prompt attempted to match iPhone visitors on Chrome, but ironically didn't match that case at all, since that user agent would mention `CriOS` and never `Chrome`.

Also:
* Updated docs to correctly mention node v6 instead of 0.10.
* The `hasSeen()` naming was confusing, since seeing the prompt doesn't in fact short-circuit it on future requests. That was actually testing whether the prompt had previously been dismissed, so I renamed the helpers but left the functionality as-is.
