### PR TITLE
@1aurabrown: update pricing label and add shipping info

### DIFF
--- a/apps/artwork/components/image/index.styl
+++ b/apps/artwork/components/image/index.styl
@@ -64,8 +64,6 @@
     clear right
 .artwork-meta-data-module .artwork-meta-data-price
   garamond-size('s-body', true)
-  .listed-price
-    float right
 
 .artwork-header-module
   height 30px

--- a/apps/artwork/components/meta_data/index.styl
+++ b/apps/artwork/components/meta_data/index.styl
@@ -3,6 +3,18 @@
 
   .artwork-meta-data-price
     margin-bottom 24px
+    .listed-price
+      float right
+    .exact-price-label
+      margin-top 16px
+      avant-garde-size('body', true)
+    .exact-listed-price
+      garamond-size('l-body')
+      font-weight bold
+    .shipping-info
+      color gray-darker-color
+      garamond-size('l-caption')
+
 
 .artwork-meta-data-black__contact-button
   avant-garde-size('body', true)

--- a/apps/artwork/components/meta_data/templates/price.jade
+++ b/apps/artwork/components/meta_data/templates/price.jade
@@ -1,4 +1,9 @@
 if artwork.sale_message && !artwork.auction
   .artwork-meta-data-price
-    span.price-label Price:
-    span.listed-price= artwork.sale_message
+    if artwork.price
+      .exact-price-label Price
+      .exact-listed-price= artwork.price
+      .shipping-info Shipping, tax, and services quoted by seller
+    else
+      span.price-label Price:
+      span.listed-price= artwork.sale_message

--- a/apps/artwork/routes.coffee
+++ b/apps/artwork/routes.coffee
@@ -17,6 +17,7 @@ query = (user) -> """
       is_inquireable
       is_acquireable
       sale_message
+      price
       is_for_sale
       medium
       edition_of


### PR DESCRIPTION
This highlights price for works with a price range or exact price and adds shipping info to inform users addition fees could be associated with purchasing the work.

Reference closed PR for context: https://github.com/artsy/microgravity/pull/69

**Highlight Price & Add Shipping Info**
![screen shot 2016-12-09 at 4 39 18 pm](https://cloud.githubusercontent.com/assets/5201004/21065437/2e6194ca-be2e-11e6-96ea-3ee2d016dcf7.png)

![screen shot 2016-12-09 at 4 39 34 pm](https://cloud.githubusercontent.com/assets/5201004/21065440/36286576-be2e-11e6-8b82-b3a890be2887.png)


**No change to the way price displays**
![screen shot 2016-12-09 at 4 39 50 pm](https://cloud.githubusercontent.com/assets/5201004/21065432/295623a6-be2e-11e6-8fbd-cf4093cb97cb.png)
