### PR TITLE
@broskoski => Dont require end_at for live sales

### DIFF
--- a/apps/artwork/components/bid/query.coffee
+++ b/apps/artwork/components/bid/query.coffee
@@ -11,6 +11,7 @@ module.exports = """
     is_with_buyers_premium
     start_at
     end_at
+    live_start_at
     sale_artwork(id: $id) {
       id
       estimate

--- a/apps/auction/test/routes.coffee
+++ b/apps/auction/test/routes.coffee
@@ -50,8 +50,10 @@ describe '/auction routes', ->
         routes.index @req, @res
         Backbone.sync.args[0][2].success fabricate 'sale',
           id: 'foobar-auction'
+          start_at: moment().subtract(2, 'days')
           live_start_at: moment().startOf('day')
           end_at: moment().endOf('day')
+          auction_state: 'open'
         Backbone.sync.args[1][2].success {}
         _.defer => _.defer =>
           @res.redirect.args[0][0].should

--- a/apps/auction/test/template.coffee
+++ b/apps/auction/test/template.coffee
@@ -33,7 +33,7 @@ describe 'auction templates', ->
             name: 'An Auction'
             start_at: moment().subtract(2, 'days').format()
             end_at: moment().add(2, 'days').format()
-          , parse: true
+
 
         benv.render resolve(__dirname, '../templates/index.jade'), data, =>
           done()
@@ -56,7 +56,8 @@ describe 'auction templates', ->
             name: 'An Auction'
             start_at: moment().add(2, 'days').format()
             end_at: moment().add(4, 'days').format()
-          ), parse: true
+            auction_state: 'preview'
+          )
 
         benv.render resolve(__dirname, '../templates/index.jade'), data, =>
           done()

--- a/components/auction_clock/test/view.coffee
+++ b/components/auction_clock/test/view.coffee
@@ -98,6 +98,7 @@ describe 'AuctionClockView', ->
         is_auction: true
         start_at: moment().subtract(2, 'minutes').format()
         end_at: moment().subtract(1, 'minutes').format()
+        auction_state: 'closed'
 
       @view.model.calculateOffsetTimes()
       Backbone.sync.args[0][2].success { time: moment().format() }
@@ -112,9 +113,9 @@ describe 'AuctionClockView', ->
         @view.model.set sale_type: 'auction promo'
 
       it 'renders the correct copy', ->
-        @view.model.set 'auctionState', 'preview'
+        @view.model.set 'clockState', 'preview'
         @view.$('h2').text().should.equal 'Auction Opens In'
-        @view.model.set 'auctionState', 'open'
+        @view.model.set 'clockState', 'open'
         @view.$('h2').text().should.equal 'Auction Closes In'
-        @view.model.set 'auctionState', 'closed'
+        @view.model.set 'clockState', 'closed'
         @view.$('h2').text().should.equal 'Auction Closed'

--- a/components/auction_clock/test/view.coffee
+++ b/components/auction_clock/test/view.coffee
@@ -107,6 +107,17 @@ describe 'AuctionClockView', ->
       @view.render()
       @triggerSpy.args[0][0].should.equal 'clock:is-over'
 
+    describe 'live auction integration', ->
+      beforeEach ->
+        @view.$el.html omg()
+        @view.model.set live_start_at: moment().add(2, 'days').format()
+
+      it 'renders the correct copy', ->
+        @view.model.set 'clockState', 'live'
+        @view.$('h2').text().should.equal 'Live Bidding Opening In'
+        @view.model.set 'clockState', 'closed'
+        @view.$('h2').text().should.equal 'Online Bidding Closed'
+
     describe 'isAuctionPromo', ->
       beforeEach ->
         @view.$el.html omg()

--- a/components/auction_clock/view.coffee
+++ b/components/auction_clock/view.coffee
@@ -35,7 +35,7 @@ module.exports = class AuctionClockView extends Backbone.View
         @$('h2').html string
         @toDate = @model.get 'offsetEndAtMoment'
       when 'live'
-        @$('h2').html 'Live Bidding Opens In'
+        @$('h2').html 'Live Bidding Opening In'
         @toDate = @model.get 'offsetLiveStartAtMoment'
       when 'closed'
         mediator.trigger 'clock:is-over'

--- a/components/auction_clock/view.coffee
+++ b/components/auction_clock/view.coffee
@@ -13,19 +13,19 @@ UNIT_MAP =
 module.exports = class AuctionClockView extends Backbone.View
   almostOver: 60
   initialize: ->
-    @listenTo @model, 'change:auctionState', @render
+    @listenTo @model, 'change:clockState', @render
 
   start: ->
     @model.calculateOffsetTimes
       success: =>
-        @model.on('change:auctionState', ->
+        @model.on('change:clockState', ->
           clearInterval @interval
           window.location.reload()
         )
         @render()
 
   render: =>
-    switch @model.get('auctionState')
+    switch @model.get('clockState')
       when 'preview'
         string = if @model.isAuctionPromo() then 'Auction Opens In' else 'Bidding Opens In'
         @$('h2').html string
@@ -34,6 +34,9 @@ module.exports = class AuctionClockView extends Backbone.View
         string = if @model.isAuctionPromo() then 'Auction Closes In' else 'Bidding Closes In'
         @$('h2').html string
         @toDate = @model.get 'offsetEndAtMoment'
+      when 'live'
+        @$('h2').html 'Live Bidding Opens In'
+        @toDate = @model.get 'offsetLiveStartAtMoment'
       when 'closed'
         mediator.trigger 'clock:is-over'
         string = if @model.isAuctionPromo() then 'Auction Closed' else 'Online Bidding Closed'

--- a/models/sale.coffee
+++ b/models/sale.coffee
@@ -120,4 +120,4 @@ module.exports = class Sale extends Backbone.Model
     [startYear..endYear]
 
   isLiveOpen: ->
-    @get('auction_state' == 'open') and moment().isAfter(@get 'live_start_at')
+    @get('auction_state') == 'open' and moment().isAfter(@get 'live_start_at')


### PR DESCRIPTION
The main change here is the copy on auction pages -- instead of _always_ saying `Bidding Closes In`, we now show the time until live bidding starts. Sales that are in live integration redirect automatically to prediction, so there wasn't much cleanup to do there.

![image](https://cloud.githubusercontent.com/assets/2081340/21118970/4a1b0a86-c08e-11e6-8089-448261133430.png)
