### PR TITLE
@sweir27 => sort by timely_at

### DIFF
--- a/apps/auctions/routes.coffee
+++ b/apps/auctions/routes.coffee
@@ -13,7 +13,7 @@ module.exports.index = (req, res) ->
   sales = new Sales
   sales.fetch
     cache: true
-    data: is_auction: true, published: true, size: 20, sort: '-end_at'
+    data: is_auction: true, published: true, size: 20, sort: '-timely_at,name'
     success: (collection, response, options) ->
       # Fetch artworks for the sale
       Q.allSettled(sales.map (sale) ->

--- a/apps/auctions/test/routes.coffee
+++ b/apps/auctions/test/routes.coffee
@@ -26,7 +26,7 @@ describe 'Auctions routes', ->
     it 'fetches the relevant auction data and renders the index template', (done) ->
       routes.index {}, @res
       Backbone.sync.args[0][1].url.should.containEql '/api/v1/sales'
-      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 20, sort: '-end_at'
+      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 20, sort: '-timely_at,name'
       Backbone.sync.args[0][2].success(@sales)
       Backbone.sync.callCount.should.equal 5
       Backbone.sync.args[1][1].url().should.containEql '/api/v1/sale/invalid-sale/sale_artworks'
@@ -56,7 +56,7 @@ describe 'Auctions routes', ->
     it 'sorts the open auctions by live_start_at or end_at', (done) ->
       routes.index {}, @res
       Backbone.sync.args[0][1].url.should.containEql '/api/v1/sales'
-      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 20, sort: '-end_at'
+      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 20, sort: '-timely_at,name'
       Backbone.sync.args[0][2].success(@sales)
       Backbone.sync.callCount.should.equal 5
       Backbone.sync.args[1][1].url().should.containEql '/api/v1/sale/invalid-sale/sale_artworks'


### PR DESCRIPTION
Small change here to sort by `-timely_at,name` instead of `-end_at`, since we can't expect all sales to have an `end_at`.