### PR TITLE
@craigspaeth make avant garde header margins identical between eigen embedded and browser

### DIFF
--- a/components/layout/stylesheets/headers.styl
+++ b/components/layout/stylesheets/headers.styl
@@ -13,9 +13,6 @@
   width 100%
   text-align center
 
-.layout-artsy-mobile-app .avant-garde-header-center
-  padding 0 30px
-
 .h2-margin
   margin 20px 0
 


### PR DESCRIPTION
talked to @mennenia about this -- there's a rule in martsy that changes the padding on avant garde headers _if_ the page is being embedded in eigen. i have no idea why, apparently this is annoying for everyone. 

fixes https://github.com/artsy/microgravity/issues/90.
for the issue in question, if you think it's a bold move to change this site wide, i can just update the css on the `/artists` page to fix it for that particular instance.