### PR TITLE
@alloy adds analytics to contact gallery link and website link

### DIFF
--- a/analytics/partners.js
+++ b/analytics/partners.js
@@ -1,0 +1,15 @@
+(function () {
+  'use strict'
+
+  $('.partner-profile-contact-email a').click(function (e) {
+    analytics.track('Clicked Contact Gallery Via Email', {
+      gallery_id: $(e.currentTarget).data('id')
+    })
+  })
+
+  $('.partner-profile-contact-website a').click(function (e) {
+    analytics.track('Clicked Gallery Website', {
+      gallery_id: $(e.currentTarget).data('id')
+    })
+  })
+})()

--- a/apps/partner_profile/templates/contact.jade
+++ b/apps/partner_profile/templates/contact.jade
@@ -10,11 +10,11 @@ block content
       h1.partner-profile-contact-email
         | Are you interested in purchasing works from #{partner.get('name')}?
         br
-        a( href=partner.getMailTo() ) Contact gallery via email.
+        a( data-id=partner.get('id'), href=partner.getMailTo() ) Contact gallery via email.
 
     if partner.has('website')
       h2.partner-profile-contact-website
-        a( href=partner.get('website'), target='_blank' )= partner.getSimpleWebsite()
+        a( data-id=partner.get('id'), href=partner.get('website'), target='_blank' )= partner.getSimpleWebsite()
 
 
     for locations, city in locationGroups

--- a/assets/mobile_analytics.coffee
+++ b/assets/mobile_analytics.coffee
@@ -22,3 +22,4 @@ $ -> analytics.ready ->
   require '../analytics/article_impressions.js'
   require '../analytics/following.js'
   require '../analytics/save.js'
+  require '../analytics/partners.js'


### PR DESCRIPTION
The microgravity equivalent of what we do in [force](https://github.com/artsy/force/pull/713) to add analytics to contact gallery link and website link on gallery contact pages. 