### PR TITLE
@craigspaeth => Load webfonts using <link> instead of script

### DIFF
--- a/components/layout/templates/head.jade
+++ b/components/layout/templates/head.jade
@@ -14,7 +14,7 @@ link( rel='apple-touch-icon', sizes='152x152', href=asset('/images/icon-152.png'
 link( rel='apple-touch-icon', href=asset('/images/icon-152.png') )
 link( href="#{sd.ARTSY_URL}#{sd.CURRENT_PATH}", rel="canonical" )
 //- Include asset package's CSS
-link( type='text/css' rel='stylesheet', href=('//fast.fonts.net/cssapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.css') )
+link( type='text/css', rel='stylesheet', href=('//fast.fonts.net/cssapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.css') )
 link( type='text/css', rel='stylesheet', href=asset('/assets/' + assetPackage + '.css') )
 //- Criteo marketing tag
 script( type='text/javascript', src='//static.criteo.net/js/ld/ld.js', async='true' )

--- a/components/layout/templates/head.jade
+++ b/components/layout/templates/head.jade
@@ -14,6 +14,7 @@ link( rel='apple-touch-icon', sizes='152x152', href=asset('/images/icon-152.png'
 link( rel='apple-touch-icon', href=asset('/images/icon-152.png') )
 link( href="#{sd.ARTSY_URL}#{sd.CURRENT_PATH}", rel="canonical" )
 //- Include asset package's CSS
+link( type='text/css' rel='stylesheet', href=('//fast.fonts.net/cssapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.css') )
 link( type='text/css', rel='stylesheet', href=asset('/assets/' + assetPackage + '.css') )
 //- Criteo marketing tag
 script( type='text/javascript', src='//static.criteo.net/js/ld/ld.js', async='true' )

--- a/components/layout/templates/scaffold.jade
+++ b/components/layout/templates/scaffold.jade
@@ -24,7 +24,6 @@ html( class=htmlClass )
 
       //- Fonts + Mixpanel, Quantcast, Google analytics script
       if sd.NODE_ENV != 'test'
-        script( type="text/javascript", src="//fast.fonts.net/jsapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.js" )
         include ./quantcast.html
         if sd.GOOGLE_ANALYTICS_ID
           include ./ga.html


### PR DESCRIPTION
Loading the fonts using a <link> fixes a CORS error we were getting
in eigen when loading microgravity pages.

With `<script>` tag:
![simulator screen shot jan 25 2017 1 17 50 pm](https://cloud.githubusercontent.com/assets/296775/22310318/e51fe88e-e31c-11e6-992c-45fa6a431c69.png)

With `<link>` tag:
![simulator screen shot jan 25 2017 4 39 38 pm](https://cloud.githubusercontent.com/assets/296775/22310321/e6c668f2-e31c-11e6-8a37-4ea681f415c6.png)

