### PR TITLE
Sort by year decs and asc

### DIFF
--- a/apps/artist/client/view.coffee
+++ b/apps/artist/client/view.coffee
@@ -28,6 +28,7 @@ module.exports = class ArtistPageView extends Backbone.View
     @artworks = new Artworks
     sort = qs.parse(location.search.replace(/^\?/, '')).sort
     filter = qs.parse(location.search.replace(/^\?/, '')).filter
+    @artworkParams.artist_id = @model.id
     @artworkParams.sort = sort if sort
     @artworkParams['filter[]'] = filter if filter
     @artworks.on 'reset add', @renderArtworks
@@ -89,7 +90,7 @@ module.exports = class ArtistPageView extends Backbone.View
 
   resetArtworks: ->
     @$('#artist-page-artworks-list').html "<div class='loading-spinner'></div>"
-    @model.fetchArtworks data: @artworkParams, success: (artworks) =>
+    @model.fetchFilteredArtworks data: @artworkParams, success: (artworks) =>
       @artworks.reset artworks.models
 
   events:
@@ -110,7 +111,7 @@ module.exports = class ArtistPageView extends Backbone.View
   seeMoreArtworks: ->
     @artworkParams.page++
     @$('.artist-page-artwork-see-more').addClass 'loading-spinner'
-    @model.fetchArtworks data: @artworkParams, success: (artworks) =>
+    @model.fetchFilteredArtworks data: @artworkParams, success: (artworks) =>
       @artworks.add artworks.models
       @$('.artist-page-artwork-see-more').removeClass 'loading-spinner'
 
@@ -118,3 +119,4 @@ module.exports = class ArtistPageView extends Backbone.View
     val = @$('#artist-page-sort select').val()
     if val then @artworkParams.sort = val else delete @artworkParams.sort
     @resetArtworks()
+

--- a/apps/artist/templates/page.jade
+++ b/apps/artist/templates/page.jade
@@ -1,7 +1,7 @@
 extends ../../../components/layout/templates/main
 
 block head
-  title #{artist.get('name')} - #{artist.get('published_artworks_count')} Artworks, Bio & Shows on Artsy 
+  title #{artist.get('name')} - #{artist.get('published_artworks_count')} Artworks, Bio & Shows on Artsy
 
 block content
   include header
@@ -17,7 +17,7 @@ block content
         | #{artist.get('forsale_artworks_count')} for sale
       #artist-page-sort
         label.garamond-select: select( dir="rtl" )
-          for val, label in { "Sort by relevance": '', "Sort by recently added": '-published_at' }
+          for val, label in { "Recently Updated": "-partner_updated_at", "Recently added": '-published_at', "Artwork year - asc": "year" , "Artwork year - desc": '-year' }
             option( value=val, selected=(sort == val) || undefined )= label
       #artist-page-artworks-list
         .loading-spinner

--- a/apps/artist/test/client.view.coffee
+++ b/apps/artist/test/client.view.coffee
@@ -38,7 +38,7 @@ describe 'ArtistPageView', ->
   describe '#initialize', ->
 
     it 'renders artworks', ->
-      Backbone.sync.args[0][2].success [
+      Backbone.sync.args[0][2].success hits: [
         fabricate 'artwork', title: "Andy Foobar's Finger Painting"
       ]
       $('body').html().should.containEql "Andy Foobar's Finger Painting"
@@ -64,11 +64,11 @@ describe 'ArtistPageView', ->
 
     it 'fetches the for sale works if that button is clicked', ->
       @view.swapArtworks target: $ "<button class='artist-page-artworks-tab-for-sale'>"
-      _.last(Backbone.sync.args)[2].data['filter[]'].should.containEql 'for_sale'
+      _.last(Backbone.sync.args)[2].data.should.containEql 'filter[]=for_sale'
 
     it 'renders the fetched artworks', ->
       @view.swapArtworks target: $ "<button class='artist-page-artworks-tab-for-sale'>"
-      _.last(Backbone.sync.args)[2].success [fabricate 'artwork', title: 'Foobaraza']
+      _.last(Backbone.sync.args)[2].success hits: [fabricate 'artwork', title: 'Foobaraza']
       $('#artist-page-artworks-list').html().should.containEql 'Foobaraza'
 
   describe '#renderArtworks', ->
@@ -83,8 +83,8 @@ describe 'ArtistPageView', ->
 
     it 'fetches more artworks and adds them to the collection', ->
       @view.seeMoreArtworks()
-      _.last(Backbone.sync.args)[2].data.page.should.be.above 1
-      _.last(Backbone.sync.args)[2].success [fabricate('artwork'), fabricate('artwork')]
+      _.last(Backbone.sync.args)[2].data.should.containEql 'page=2'
+      _.last(Backbone.sync.args)[2].success hits: [fabricate('artwork'), fabricate('artwork')]
       @view.artworks.length.should.be.above 1
 
   describe '#followArtist', ->
@@ -126,16 +126,16 @@ describe 'ArtistPageView', ->
         @view.followArtists.follow.restore()
         location.href.should.containEql "/log_in?redirect-to="
 
-    describe '#resetArtworks', ->
+  describe '#resetArtworks', ->
 
-      it 'fetches the artworks with the params', ->
-        @view.artworkParams.foo = 'bar'
-        @view.resetArtworks()
-        Backbone.sync.args[0][2].data.foo.should.equal 'bar'
+    it 'fetches the artworks with the params', ->
+      @view.artworkParams.sort = 'title'
+      @view.resetArtworks()
+      Backbone.sync.args[0][2].data.should.containEql 'sort=title'
 
-    describe '#sortArtworks', ->
+  describe '#sortArtworks', ->
 
-      it 'sorts the artworks based on the select value', ->
-        @view.$('#artist-page-sort select').val '-published_at'
-        @view.sortArtworks()
-        Backbone.sync.args[0][2].data.sort.should.equal '-published_at'
+    it 'sorts the artworks based on the select value', ->
+      @view.$('#artist-page-sort select').val '-published_at'
+      @view.sortArtworks()
+      Backbone.sync.args[0][2].data.should.containEql '-published_at'

--- a/apps/artist/test/client.view.coffee
+++ b/apps/artist/test/client.view.coffee
@@ -131,11 +131,11 @@ describe 'ArtistPageView', ->
     it 'fetches the artworks with the params', ->
       @view.artworkParams.sort = 'title'
       @view.resetArtworks()
-      Backbone.sync.args[0][2].data.should.containEql 'sort=title'
+      _.last(Backbone.sync.args)[2].data.should.containEql 'sort=title'
 
   describe '#sortArtworks', ->
 
     it 'sorts the artworks based on the select value', ->
       @view.$('#artist-page-sort select').val '-published_at'
       @view.sortArtworks()
-      Backbone.sync.args[0][2].data.should.containEql '-published_at'
+      _.last(Backbone.sync.args)[2].data.should.containEql '-published_at'

--- a/models/artist.coffee
+++ b/models/artist.coffee
@@ -1,6 +1,7 @@
 Backbone = require 'backbone'
 sd = require('sharify').data
 Artworks = require '../collections/artworks.coffee'
+FilteredArtworks = require '../collections/filter_artworks.coffee'
 Artists = require '../collections/artists.coffee'
 _ = require 'underscore'
 { Markdown } = require 'artsy-backbone-mixins'
@@ -36,6 +37,10 @@ module.exports = class Artist extends Backbone.Model
   fetchArtworks: (options = {}) ->
     artworks = new Artworks
     artworks.url = @url() + '/artworks'
+    artworks.fetch options
+
+  fetchFilteredArtworks: (options = {}) ->
+    artworks = new FilteredArtworks
     artworks.fetch options
 
   fetchRelatedArtists: (options = {}) ->

--- a/test/models/artist.coffee
+++ b/test/models/artist.coffee
@@ -66,3 +66,15 @@ describe 'Artist', ->
       @artist.set image_url: 'cat/bitty/:version.jpg'
       @artist.set image_versions: [ 'four_thirds', 'other' ]
       @artist.defaultImageUrl().should.equal 'cat/bitty/four_thirds.jpg'
+
+  describe '#fetchFilteredArtworks', ->
+
+    it 'fetches the filtered artists artworks', (done) ->
+      @artist.fetchFilteredArtworks
+        data: { sort: 'title' } ,
+        success: (artworks) ->
+          artworks.first().get('title').should.equal 'Blahwork'
+          done()
+      Backbone.sync.args[0][2].success hits: [fabricate('artwork', title: 'Blahwork')]
+      Backbone.sync.args[0][1].url.should.match /// /api/v1/filter/artworks ///
+      Backbone.sync.args[0][2].data.should.equal 'sort=title'


### PR DESCRIPTION
closes: https://github.com/artsy/microgravity/issues/86

This adds the additional sort options to match those available in force. Because you can't sort by year with the `/artist/:id/artworks` endpoind, I've replaced it with the `/filter/artworks/` endpoint. This is a work in progress because I can't seem to get the last to tests to pass. I'm wondering if you see anything obvious that I might be missing.