### PR TITLE
@dblock: Fix browse link and redirect

### DIFF
--- a/apps/browse/routes.coffee
+++ b/apps/browse/routes.coffee
@@ -1,6 +1,7 @@
-@to = (path) -> (req, res) ->
-  params = url.parse req.url
-    .search or ''
+url = require 'url'
+
+module.exports.to = (path) -> (req, res) ->
+  params = url.parse(req.url).search or ''
   res.redirect 301, path + params
 
 module.exports.index = (req, res) ->

--- a/apps/browse/test/routes.coffee
+++ b/apps/browse/test/routes.coffee
@@ -1,0 +1,12 @@
+routes = require '../routes'
+sinon = require 'sinon'
+
+describe 'routes #to', ->
+  beforeEach ->
+    @req = url: 'http://artsy.net/foo/bar'
+    @res = redirect: sinon.stub()
+
+  it 'redirects to a url', ->
+    routes.to('baz') @req, @res, @next
+    @res.redirect.args[0][0].should.equal 301
+    @res.redirect.args[0][1].should.equal 'baz'

--- a/apps/home/templates/page.jade
+++ b/apps/home/templates/page.jade
@@ -20,7 +20,7 @@ block content
   section.main-side-margin.home-page-section
     h1.avant-garde-header-center Explore Artsy
     nav#home-page-featured-list.chevron-nav-list
-      a#home-page-featured-works( href='/browse' ) Featured Artworks
+      a#home-page-featured-works( href='/collect' ) Featured Artworks
       a#home-page-featured-articles( href='/articles' ) Featured Articles
   section.main-side-margin.home-page-section
     h1.avant-garde-header-center Current Shows


### PR DESCRIPTION
Changes the link and adds a test (!!) to the route that was supposed to redirect /browse to /collect.