### PR TITLE
@mzikherman Login/Signup updates

### DIFF
--- a/apps/auth/routes.coffee
+++ b/apps/auth/routes.coffee
@@ -10,9 +10,9 @@ sanitizeRedirect = require '../../components/sanitize_redirect'
 redirectUrl = (req) ->
   url = req.body['redirect-to'] or
   req.query['redirect-to'] or
-  req.param('redirect_uri') or
+  req.params['redirect_uri'] or
 
-  if referrer = req.get('Referrer') && (referrer.indexOf('/log_in') > -1) and (referrer.indexOf('/sign_up') > -1)
+  if (referrer = req.get('Referrer')) && (referrer.indexOf('/log_in') > -1) and (referrer.indexOf('/sign_up') > -1)
     url ?= req.get('Referrer')
 
   return if not url

--- a/apps/auth/routes.coffee
+++ b/apps/auth/routes.coffee
@@ -7,21 +7,26 @@ qs = require 'querystring'
 { API_URL } = require '../../config'
 sanitizeRedirect = require '../../components/sanitize_redirect'
 
-module.exports.login = (req, res) ->
+redirectUrl = (req) ->
   url = req.body['redirect-to'] or
-    req.query['redirect-to'] or
-    req.param('redirect_uri') or
-    req.get('Referrer') or
-    '/'
+  req.query['redirect-to'] or
+  req.param('redirect_uri') or
 
+  if referrer = req.get('Referrer') && (referrer.indexOf('/log_in') > -1) and (referrer.indexOf('/sign_up') > -1)
+    url ?= req.get('Referrer')
+
+  return if not url
+  sanitizeRedirect(url)
+
+module.exports.login = (req, res) ->
   locals =
-    action: req.query?.action or req.session?.action
-    redirectTo: sanitizeRedirect(url)
-  if req.query.action
-    locals.action = req.query.action
+    redirectTo: redirectUrl(req)
+    action: req.query.action
+
+  if locals.action
     res.render 'call_to_action', locals
   else
-    res.render 'login', action: true, redirectTo: sanitizeRedirect(url)
+    res.render 'login', locals
 
 module.exports.forgotPassword = (req, res) ->
   res.render 'forgot_password'
@@ -38,16 +43,12 @@ module.exports.resetPassword = (req, res) ->
   res.render 'reset_password'
 
 module.exports.signUp = (req, res) ->
-  req.session.signupReferrer ?= req.query['redirect-to'] or req.get('Referrer')
-  req.session.action ?= req.query.action
   locals =
-    redirect: sanitizeRedirect(req.body['redirect-to'] or req.session.signupReferrer or '/')
-    redirectTo: sanitizeRedirect(req.query['redirect-to'] or '/personalize/collect')
-    action: req.query.action or req.session.action
+    redirectTo: redirectUrl(req)
+    action: req.query.action
     error: err?.body.error
     prefill: req.query.prefill
-  if req.query.action
-    locals.action = req.query.action
+  if locals.action
     res.render 'call_to_action', locals
   else if req.query.email
     res.render 'signup_email', locals

--- a/apps/auth/templates/call_to_action.jade
+++ b/apps/auth/templates/call_to_action.jade
@@ -21,18 +21,14 @@ block body
         | need an Artsy account.
     .auth-page-error-message
     nav#auth-call-to-action-tabs
-      if action && redirectTo
-        a.auth-page-cta__signup-tab(
-          href="#{sd.AP.signupPagePath}?action=#{action}&redirect-to=#{redirectTo}"
-          class=sd.CURRENT_PATH.includes('/sign_up') ? 'auth-call-to-action-tabs-active' : ''
-        ) Sign Up
-        a.auth-page-cta__login-tab(
-          href="#{sd.AP.loginPagePath}?action=#{action}&redirect-to=#{redirectTo}"
-          class=sd.CURRENT_PATH.includes('/log_in') ? 'auth-call-to-action-tabs-active' : ''
-        ) Log in
-      else
-        a.auth-page-cta__signup-tab Sign Up
-        a.auth-page-cta__login-tab Log in
+      a.auth-page-cta__signup-tab(
+        href="#{sd.AP.signupPagePath}?action=#{action}" + (redirectTo ? "&redirect-to=#{redirectTo}" : '')
+        class=sd.CURRENT_PATH.includes('/sign_up') ? 'auth-call-to-action-tabs-active' : ''
+      ) Sign Up
+      a.auth-page-cta__login-tab(
+        href="#{sd.AP.loginPagePath}?action=#{action}" + (redirectTo ? "&redirect-to=#{redirectTo}" : '')
+        class=sd.CURRENT_PATH.includes('/log_in') ? 'auth-call-to-action-tabs-active' : ''
+      ) Log in
     ul#auth-call-to-action-forms
       li(class=sd.CURRENT_PATH.includes('/sign_up') ? 'auth-call-to-action-form-active' : '')
         include signup_buttons

--- a/apps/auth/templates/login_form.jade
+++ b/apps/auth/templates/login_form.jade
@@ -20,4 +20,4 @@ form( action=sd.AP.loginPagePath, method='POST' )
     .loading-spinner
   .auth-page-center
     a#auth-page-forgot-password( href='/forgot_password' ) Forgot password?
-    a#auth-page-sign-up( href=(redirectTo ? "/sign_up?redirect-to=#{redirectTo}" : '/sign_up') ) Sign up for Artsy
+    a#auth-page-sign-up( href=('/sign_up' + (redirectTo ? "?redirect-to=#{redirectTo}" : '')) ) Sign up for Artsy

--- a/apps/auth/templates/signup.jade
+++ b/apps/auth/templates/signup.jade
@@ -7,5 +7,5 @@ block body
       .auth-page-error-message= error
     include signup_buttons
     include signup_append
-    p.auth-page-nevermind Already have an account? 
-      a( href='/log_in' ) Log in
+    p.auth-page-nevermind Already have an account?
+      a( href='/log_in' + (redirectTo ? '?redirectTo=#{redirectTo}' : '' )) Log in

--- a/apps/auth/templates/signup_buttons.jade
+++ b/apps/auth/templates/signup_buttons.jade
@@ -1,7 +1,7 @@
 #auth-page-signup-social
   a.auth-page-facebook.avant-garde-box-button.avant-garde-box-button-black(
-    href='/users/auth/facebook?redirect-to=#{redirectTo}'
+    href="/users/auth/facebook?redirect-to=#{redirectTo ? redirectTo : '/personalize/collect'}"
   ) Facebook
   a.avant-garde-box-button.avant-garde-box-button-black(
-    href='/sign_up?email=1&redirect-to=#{redirectTo}'
+    href="/sign_up?email=1&redirect-to=#{redirectTo ? redirectTo : '/personalize/collect'}"
   ) Your email address

--- a/apps/auth/test/routes.coffee
+++ b/apps/auth/test/routes.coffee
@@ -36,7 +36,7 @@ describe '#login', ->
       get: (=> @redirectURL)
       query: {}
       body: {}
-      param: (-> false)
+      params: {}
 
     @res = { render: @render = sinon.stub() }
 
@@ -53,7 +53,7 @@ describe '#login', ->
         'redirect-to': @redirectURL
       }
       body: {}
-      param: (-> false)
+      params: {}
 
     @res = { render: @render = sinon.stub() }
 
@@ -68,7 +68,7 @@ describe '#login', ->
     req =
       query: { 'redirect-to': '%2Ffollowing%2Fprofiles' }
       body: {}
-      param: (-> false)
+      params: {}
       get: (-> false)
     res = { render: @render = sinon.stub() }
 
@@ -79,7 +79,7 @@ describe '#login', ->
     req =
       query: { 'redirect-to': 'http://www.iamveryverysorry.com/' }
       body: {}
-      param: (-> false)
+      params: {}
       get: (-> false)
 
     res = { render: @render = sinon.stub() }
@@ -89,22 +89,13 @@ describe '#login', ->
 
 describe '#signUp', ->
   beforeEach ->
-    @req = { session: @session = {}, get: (-> '/auctions/two-x-two'), query: {}, body: {} }
+    @req = { session: {}, get: (-> '/auctions/two-x-two'), query: {}, body: {}, params: {}}
     @res = { render: @render = sinon.stub() }
     sinon.stub Backbone, 'sync'
 
   afterEach ->
     @render.restore?()
     Backbone.sync.restore()
-
-  it 'sets the signupReferrer in the session', ->
-    routes.signUp @req, @res
-    @session.signupReferrer.should.containEql '/auctions/two-x-two'
-
-  it 'sets the action in the session', ->
-    @req.query.action = 'register-for-auction'
-    routes.signUp @req, @res
-    @session.action.should.equal 'register-for-auction'
 
   it 'renders the call_to_action if coming from an action', ->
     @req.query.action = 'register-for-auction'
@@ -129,7 +120,7 @@ describe '#signUp', ->
     @render.args[0][1].redirectTo.should.equal '/auction-registration'
 
   it 'ignores malicious redirects', ->
-    req = query: { 'redirect-to': 'http://www.iamveryverysorry.com/' }, body: {}, session: {}
+    req = query: { 'redirect-to': 'http://www.iamveryverysorry.com/' }, body: {}, session: {}, params: {}
     routes.signUp req, @res
     @render.args[0][1].redirectTo.should.equal '/'
 


### PR DESCRIPTION
I was trying to fix https://github.com/artsy/microgravity/issues/110, but wasn't able to reproduce it exactly. I did notice some cases where the redirect parameter was getting over written if you toggled between Sign Up and Log In. For example, if no explicit redirect param was included in the request, then the referrer is used. If you have toggled from sign up to login, then the redirect after login would be to the sign up page. There were also some things getting stored to session or request variables that was then ever being referenced, or in ever case being overwritten at some subsequent line. I tried to remove these.