### PR TITLE
@xitna-starr: respect for_sale parameter on artist page

### DIFF
--- a/apps/artist/index.styl
+++ b/apps/artist/index.styl
@@ -26,6 +26,7 @@
     display inline-block
     width 50%
     &.artist-page-artworks-tab-active
+      pointer-events none
       color black
       border-color black
     &:active, &:focus

--- a/apps/artist/test/client.view.coffee
+++ b/apps/artist/test/client.view.coffee
@@ -64,7 +64,7 @@ describe 'ArtistPageView', ->
 
     it 'fetches the for sale works if that button is clicked', ->
       @view.swapArtworks target: $ "<button class='artist-page-artworks-tab-for-sale'>"
-      _.last(Backbone.sync.args)[2].data.should.containEql 'filter[]=for_sale'
+      _.last(Backbone.sync.args)[2].data.should.containEql 'for_sale=true'
 
     it 'renders the fetched artworks', ->
       @view.swapArtworks target: $ "<button class='artist-page-artworks-tab-for-sale'>"


### PR DESCRIPTION
fixes https://github.com/artsy/microgravity/issues/85

the for_sale parameter was not being handled. we were using filter[]=for_sale when parsing parameters, and when fetching works from gravity. this seems to include sold auction works. I switched client param parsing and params sent to gravity to use for_sale instead.