### PR TITLE
make sure past shows show up on mobile

### DIFF
--- a/apps/partner_profile/templates/shows.jade
+++ b/apps/partner_profile/templates/shows.jade
@@ -9,10 +9,10 @@ mixin show-list(shows)
             h3= show.get('name')
             h4!= show.formattedDateRange()
 
-if currentShows
+if currentShows && currentShows.length
   h1.avant-garde-header-center.partner-profile-large-header Current & Upcoming Shows
-  mixin show-list(currentShows)
+  mixin show-list(currentShows.models)
 
-if pastShows
+if pastShows && pastShows.length
   h1.avant-garde-header-center.partner-profile-large-header Past Shows
-  mixin show-list(pastShows)
+  mixin show-list(pastShows.models)

--- a/apps/partner_profile/test/routes.coffee
+++ b/apps/partner_profile/test/routes.coffee
@@ -28,20 +28,29 @@ describe 'Profile page', ->
   describe '#shows', ->
 
     it 'renders the shows page passing on the current shows, upcoming shows and past shows', ->
+      Backbone.sync
+        .onCall 0
+        .yieldsTo 'success', [ fabricate('show', status: 'running', name: 'Foo') ]
+        .returns Promise.resolve [ fabricate('show', status: 'running', name: 'Foo') ]
+      Backbone.sync
+        .onCall 1
+        .yieldsTo 'success', [ fabricate('show', status: 'upcoming', name: 'Meow') ]
+        .returns Promise.resolve [ fabricate('show', status: 'upcoming', name: 'Meow') ]
+      Backbone.sync
+        .onCall 2
+        .yieldsTo 'success', [ fabricate('show', status: 'closed', name: 'Bar') ]
+        .returns Promise.resolve [ fabricate('show', status: 'closed', name: 'Bar') ]
+
+      renderStub = sinon.stub()
       routes.shows(
         { profile: new Profile(fabricate 'profile', name: 'Foobarz', owner_type: 'PartnerGallery') }
-        { render: renderStub = sinon.stub() }
-      )
-      Backbone.sync.args[0][2].success [
-        fabricate('show', status: 'running', name: 'Foo')
-        fabricate('show', status: 'upcoming', name: 'Meow')
-        fabricate('show', status: 'closed', name: 'Bar')
-      ]
-      renderStub.args[0][0].should.equal 'shows_page'
-      renderStub.args[0][1].profile.get('name').should.equal 'Foobarz'
-      renderStub.args[0][1].currentShows[0].get('name').should.equal 'Foo'
-      renderStub.args[0][1].currentShows[1].get('name').should.equal 'Meow'
-      renderStub.args[0][1].pastShows[0].get('name').should.equal 'Bar'
+        { render: renderStub }
+      ).then ->
+        renderStub.args[0][0].should.equal 'shows_page'
+        renderStub.args[0][1].profile.get('name').should.equal 'Foobarz'
+        renderStub.args[0][1].currentShows.models[0].get('name').should.equal 'Foo'
+        renderStub.args[0][1].currentShows.models[1].get('name').should.equal 'Meow'
+        renderStub.args[0][1].pastShows.models[0].get('name').should.equal 'Bar'
 
   describe '#artists', ->
 


### PR DESCRIPTION
fixes https://github.com/artsy/microgravity/issues/114
@ashkan18 there were 2 problems 
- the check for pastShows should have been checking for array length, not just presence of a (possibly empty) array
- shows were being fetched all in one request, then divided by whether they are current/upcoming or closed. If there is more than a page of current/upcoming shows, no closed shows are returned in the response. Split this into two parallel requests so we get up to ten in each section.